### PR TITLE
MC-OST logging is now more condensed

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/Thermodynamics.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/Thermodynamics.groovy
@@ -106,6 +106,14 @@ class Thermodynamics extends AlgorithmsScript {
     private ThermodynamicsOptions thermodynamics
 
     /**
+     * -r or --rectangular uses a rectangular prism as the output rather than a cube;
+     * this reduces overall box size, but is not recommended for simulations long enough to see solute rotation.
+     */
+    @CommandLine.Option(names = ['-v', '--verbose'],
+            description = "Log additional information (primarily for MC-OSRW).")
+    private boolean verbose = false;
+
+    /**
      * The final argument(s) should be one or more filenames.
      */
     @CommandLine.Parameters(arity = "1..*", paramLabel = "files", description = 'The atomic coordinate file in PDB or XYZ format.')
@@ -261,7 +269,7 @@ class Thermodynamics extends AlgorithmsScript {
                             dynamics, lambdaParticle, barostat, hisExists)
 
                     if (osrwOptions.mc) {
-                        osrwOptions.beginMCOSRW(osrw, topologies, osrwPotential, dynamics, writeout, thermodynamics, dyn, algorithmListener)
+                        osrwOptions.beginMCOSRW(osrw, topologies, dynamics, thermodynamics, verbose);
                     } else {
                         osrwOptions.beginMDOSRW(osrw, topologies, osrwPotential, dynamics, writeout, thermodynamics, dyn, algorithmListener)
                     }

--- a/modules/algorithms/src/main/java/ffx/algorithms/cli/OSRWOptions.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/cli/OSRWOptions.java
@@ -307,21 +307,17 @@ public class OSRWOptions {
      *
      * @param ttOSRW         a {@link TransitionTemperedOSRW} object.
      * @param topologies     an array of {@link ffx.potential.MolecularAssembly} objects.
-     * @param potential      a {@link ffx.crystal.CrystalPotential} object.
      * @param dynamics       a {@link ffx.algorithms.cli.DynamicsOptions} object.
-     * @param writeout       a {@link WriteoutOptions} object.
      * @param thermodynamics a {@link ffx.algorithms.cli.ThermodynamicsOptions} object.
-     * @param dyn            a {@link java.io.File} object.
-     * @param aListener      a {@link ffx.algorithms.AlgorithmListener} object.
+     * @param verbose        Whether to print out additional information about MC-OSRW.
      */
-    public void beginMCOSRW(TransitionTemperedOSRW ttOSRW, MolecularAssembly[] topologies, CrystalPotential potential,
-                            DynamicsOptions dynamics, WriteoutOptions writeout, ThermodynamicsOptions thermodynamics,
-                            File dyn, AlgorithmListener aListener) {
+    public void beginMCOSRW(TransitionTemperedOSRW ttOSRW, MolecularAssembly[] topologies,
+                            DynamicsOptions dynamics, ThermodynamicsOptions thermodynamics, boolean verbose) {
 
         dynamics.init();
 
         MonteCarloOSRW mcOSRW = new MonteCarloOSRW(ttOSRW.getPotentialEnergy(), ttOSRW, topologies[0],
-                topologies[0].getProperties(), null, ThermostatEnum.ADIABATIC, dynamics.integrator);
+                topologies[0].getProperties(), null, ThermostatEnum.ADIABATIC, dynamics.integrator, verbose);
 
         int nEquil = thermodynamics.getEquilSteps();
         if (nEquil > 0) {

--- a/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
@@ -135,7 +135,7 @@ public class MDMove implements MCMove {
         }
 
         molecularDynamics.init(mdSteps, timeStep, printInterval, saveInterval, temperature, true, dyn);
-        molecularDynamics.setQuiet(true);
+        molecularDynamics.setVerbosityLevel(MolecularDynamics.VerbosityLevel.QUIET);
     }
 
     /**
@@ -164,7 +164,16 @@ public class MDMove implements MCMove {
      */
     @Override
     public void move() {
+        move(MolecularDynamics.VerbosityLevel.QUIET);
+    }
 
+    /**
+     * Performs an MDMove.
+     * @param verbosityLevel How verbose to be.
+     */
+    public void move(MolecularDynamics.VerbosityLevel verbosityLevel) {
+        MolecularDynamics.VerbosityLevel origLevel = molecularDynamics.getVerbosityLevel();
+        molecularDynamics.setVerbosityLevel(verbosityLevel);
         mdMoveCounter++;
 
         boolean initVelocities = true;
@@ -187,6 +196,7 @@ public class MDMove implements MCMove {
             logger.fine(format(" Mean singed/unsigned energy drift per psec per atom: %8.4f/%8.4f\n",
                     normalizedEnergyDriftNet, normalizedEnergyDriftAbs));
         }
+        molecularDynamics.setVerbosityLevel(origLevel);
     }
     
     public void setMDIntervalSteps(int intervalSteps){

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/Solvator.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/Solvator.groovy
@@ -647,6 +647,10 @@ class Solvator extends PotentialScript {
             logger.severe(" Could not find an unused character A-Z for the new solvent!");
         }
         logger.info(" New solvent molecules will be placed in chain ${solventChain}");
+        if (ionChain == ' '.charAt(0)) {
+            logger.severe(" Could not find an unused character A-Z for the new solvent!");
+        }
+        logger.info(" New ions will be placed in chain ${ionChain}");
 
         // Accumulator for new solvent molecules.
         // Currently implemented as an ArrayList with the notion of removing from the end of the List.


### PR DESCRIPTION
Unless a -v flag is provided, MC-OST is much less verbose. This required some changes in MolecularDynamics and MolecularDynamicsOpenMM to suppress its logging.