### PR TITLE
Trialing use of a convex hull to calculate max particle-particle distance in aperiodic systems

### DIFF
--- a/Licenses/quickhull3d-license.txt
+++ b/Licenses/quickhull3d-license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2004 - 2014, John E. Lloyd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/Licenses/readme
+++ b/Licenses/readme
@@ -40,3 +40,5 @@ MRJ Toolkit Stubs: License could not be found.
 
 guava-license.txt: Apache 2.0 license: covers Guava (Google core utils for Java).
 
+quickhull3d-license.txt: BSD 2.0 license: covers use of the QuickHull3D package.
+

--- a/modules/potential/pom.xml
+++ b/modules/potential/pom.xml
@@ -156,6 +156,11 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.quickhull3d</groupId>
+            <artifactId>quickhull3d</artifactId>
+            <version>${quickhull3D.version}</version>
+        </dependency>
         <!-- dependency>
             <groupId>org.tensorflow</groupId>
             <artifactId>libtensorflow</artifactId>

--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
@@ -49,7 +49,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
@@ -57,8 +56,6 @@ import static java.lang.String.format;
 import static java.util.Arrays.fill;
 import static java.util.Arrays.sort;
 
-import com.sun.xml.bind.v2.runtime.reflect.opt.Const;
-import ffx.numerics.math.VectorMath;
 import ffx.potential.utils.ConvexHullOps;
 import ffx.utilities.Constants;
 import org.apache.commons.configuration2.CompositeConfiguration;
@@ -125,9 +122,6 @@ import ffx.potential.utils.EnergyException;
 import ffx.potential.utils.PotentialsFunctions;
 import ffx.potential.utils.PotentialsUtils;
 import static ffx.potential.parameters.ForceField.toEnumForm;
-
-import com.github.quickhull3d.QuickHull3D;
-import org.apache.commons.math3.util.FastMath;
 
 /**
  * Compute the potential energy and derivatives of a molecular system

--- a/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
@@ -1,0 +1,145 @@
+//******************************************************************************
+//
+// Title:       Force Field X.
+// Description: Force Field X - Software for Molecular Biophysics.
+// Copyright:   Copyright (c) Michael J. Schnieders 2001-2019.
+//
+// This file is part of Force Field X.
+//
+// Force Field X is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+//
+// Force Field X is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Force Field X; if not, write to the Free Software Foundation, Inc., 59 Temple
+// Place, Suite 330, Boston, MA 02111-1307 USA
+//
+// Linking this library statically or dynamically with other modules is making a
+// combined work based on this library. Thus, the terms and conditions of the
+// GNU General Public License cover the whole combination.
+//
+// As a special exception, the copyright holders of this library give you
+// permission to link this library with independent modules to produce an
+// executable, regardless of the license terms of these independent modules, and
+// to copy and distribute the resulting executable under terms of your choice,
+// provided that you also meet, for each linked independent module, the terms
+// and conditions of the license of that module. An independent module is a
+// module which is not derived from or based on this library. If you modify this
+// library, you may extend this exception to your version of the library, but
+// you are not obligated to do so. If you do not wish to do so, delete this
+// exception statement from your version.
+//
+//******************************************************************************
+package ffx.potential.utils;
+
+import com.github.quickhull3d.QuickHull3D;
+
+import ffx.numerics.math.VectorMath;
+import ffx.potential.MolecularAssembly;
+import ffx.potential.bonded.Atom;
+import ffx.utilities.Constants;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+
+/**
+ * This ConvexHullOps class uses the QuickHull3D package by John E. Lloyd to
+ * construct and operate on 3D convex hulls: the minimal convex polyhedron
+ * that contains all points in a set of points. This is especially useful
+ * for max-dist operations, as the most distant points in a set are guaranteed
+ * to be part of the convex polyhedron.
+ *
+ * The QuickHull3D package website is at quickhull3d.github.io/quickhull3d/
+ * The algorithm it uses is described in Barber, Dobkin, and Huhdanpaa,
+ * "The Quickhull Algorithm for Convex Hulls" (ACM Transactions on Mathematical
+ * Software, Vol. 22, No. 4, December 1996), and the code is based on the C
+ * package qhull.
+ *
+ * @author Jacob M. Litman
+ * @author Michael J. Schnieders
+ * @since 1.0.0
+ */
+public class ConvexHullOps {
+    private static final Logger logger = Logger.getLogger(ConvexHullOps.class.getName());
+
+    /**
+     * Constructs a convex hull from a MolecularAssembly.
+     * @param ma MolecularAssembly to build a convex hull for.
+     * @return   A QuickHull3D implementation of convex hulls.
+     */
+    public static QuickHull3D constructHull(MolecularAssembly ma) {
+        Atom[] atoms = ma.getAtomArray();
+        return constructHull(atoms);
+    }
+
+    /**
+     * Constructs a convex hull from a set of atoms.
+     * @param atoms Atoms to build a convex hull for.
+     * @return      A QuickHull3D implementation of convex hulls.
+     */
+    public static QuickHull3D constructHull(Atom[] atoms) {
+        int nAts = atoms.length;
+        double[] xyz = new double[nAts * 3];
+        for (int i = 0; i < nAts; i++) {
+            Atom at = atoms[i];
+            int i3 = 3*i;
+            xyz[i3] = at.getX();
+            xyz[i3 + 1] = at.getY();
+            xyz[i3 + 2] = at.getZ();
+        }
+        return new QuickHull3D(xyz);
+    }
+
+    /**
+     * Find the maximum pairwise distance between vertex points on a convex hull.
+     * @param qh A QuickHull3D object.
+     * @return   Maximum vertex-vertex distance.
+     */
+    public static double maxDist(QuickHull3D qh) {
+        long time = -System.nanoTime();
+        int nVerts = qh.getNumVertices();
+        assert nVerts > 1;
+        double[] vertPoints = new double[3*nVerts];
+        qh.getVertices(vertPoints);
+        double maxDist = IntStream.range(0, nVerts).
+                parallel().
+                mapToDouble((int i) -> {
+                    double[] xyz = new double[3];
+                    System.arraycopy(vertPoints, 3*i, xyz, 0, 3);
+                    double mij = 0;
+                    for (int j = i + 1; j < nVerts; j++) {
+                        double[] xyzJ = new double[3];
+                        System.arraycopy(vertPoints, 3*j, xyzJ, 0, 3);
+                        double distIJ = VectorMath.dist2(xyz, xyzJ);
+                        mij = Math.max(mij, distIJ);
+                    }
+                    return mij;
+                }).
+                max().getAsDouble();
+        time += System.nanoTime();
+        if (time > 1E9) {
+            logger.warning(String.format(" Required %12.6g sec to find max distance on a convex hull." +
+                    " It may be time to further optimize this!", Constants.NS2SEC * time));
+        }
+        return maxDist;
+    }
+
+    /**
+     * UNTESTED: Identifies atoms forming the convex hull.
+     * @param qh       A QuickHull3D.
+     * @param allAtoms Atoms used in building the QuickHull3D.
+     * @return         Atoms forming the convex hull.
+     */
+    public static Atom[] identifyHullAtoms(QuickHull3D qh, Atom[] allAtoms) {
+        int[] indices = qh.getVertexPointIndices();
+        return Arrays.stream(indices).
+                mapToObj((int i) -> allAtoms[i]).
+                toArray(Atom[]::new);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1189,6 +1189,7 @@
         <properties.version>1.0.0</properties.version>
         <!-- Clover Plugin -->
         <clover.version>4.3.1</clover.version>
+        <quickhull3D.version>1.0.0</quickhull3D.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Currently, on setup, an O(n^2) brute-force loop is used to evaluate max particle-particle distance for aperiodic systems. This adds use of a convex hull (based on the open-source QuickHull3D package) to calculate this. Currently, this is only done as a check: the brute-force loop still calculates max distance and a warning message is printed if the convex hull differs by more than 1E-5 Angstroms.

I figure that if we keep this in the code for a few months and no issues arise, we can switch to the convex hull method full-time.