### PR TITLE
More robust ion parsing

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
@@ -850,17 +850,19 @@ public class ForceFieldEnergy implements CrystalPotential, LambdaInterface {
                 }
             }
             convTime += System.nanoTime();
-            long hullTime = -System.nanoTime();
-            double maxC = ConvexHullOps.maxDist(ConvexHullOps.constructHull(atoms));
-            maxC = Math.max(10.0, maxC);
-            hullTime += System.nanoTime();
-            double diff = maxr - maxC;
-            if (Math.abs(diff) > 1.0E-5) {
-                logger.warning(String.format(" Max particle-particle distance by convex hull %12.6g " +
-                        "disagrees with max distance by brute-force loop %12.6g: difference %12.6g!", maxC, maxr, diff));
-            }
-            logger.fine(String.format(" Time for convex hull calculation: %12.6g sec. By O(n^2) " +
-                    "loop: %12.6g sec.", hullTime * Constants.NS2SEC, convTime * Constants.NS2SEC));
+            if (nAtoms > 10) {
+                long hullTime = -System.nanoTime();
+                double maxC = ConvexHullOps.maxDist(ConvexHullOps.constructHull(atoms));
+                maxC = Math.max(10.0, maxC);
+                hullTime += System.nanoTime();
+                double diff = maxr - maxC;
+                if (Math.abs(diff) > 1.0E-5) {
+                    logger.warning(String.format(" Max particle-particle distance by convex hull %12.6g " +
+                            "disagrees with max distance by brute-force loop %12.6g: difference %12.6g!", maxC, maxr, diff));
+                }
+                logger.fine(String.format(" Time for convex hull calculation: %12.6g sec. By O(n^2) " +
+                        "loop: %12.6g sec.", hullTime * Constants.NS2SEC, convTime * Constants.NS2SEC));
+            } // At N < 4, the 3D convex hull may not even be defined properly, nevermind be more efficient.
 
             // Turn off reciprocal space calculations.
             forceField.addProperty("EWALD_ALPHA", "0.0");

--- a/modules/potential/src/main/java/ffx/potential/MolecularAssembly.java
+++ b/modules/potential/src/main/java/ffx/potential/MolecularAssembly.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
+import ffx.utilities.StringUtils;
 import org.apache.commons.configuration2.CompositeConfiguration;
 import org.jogamp.java3d.Appearance;
 import org.jogamp.java3d.BoundingSphere;
@@ -1617,23 +1618,26 @@ public class MolecularAssembly extends MSGroup {
         }
 
         if (create) {
+            boolean isWater = false;
+            boolean isIon = false;
+            if (StringUtils.looksLikeWater(resName)) {
+                resName = StringUtils.STANDARD_WATER_NAME;
+                isWater = true;
+            } else if (StringUtils.looksLikeIon(resName)) {
+                resName = StringUtils.tryParseIon(resName);
+                isIon = true;
+            }
+            atom.setResName(resName);
             m = new Molecule(resName, resNum, chainID, segID);
             m.addMSNode(atom);
             if (resName == null) {
                 logger.warning(format(" Attempting to create a molecule %s with a null name on atom %s! Defaulting to creating a generic Molecule.", m, atom));
                 molecules.add(m);
                 moleculeHashMap.put(key, m);
-            } else if (resName.equalsIgnoreCase("DOD")
-                    || resName.equalsIgnoreCase("HOH")
-                    || resName.equalsIgnoreCase("WAT")) {
+            } else if (isWater) {
                 water.add(m);
                 waterHashMap.put(key, m);
-                // NA, K, MG, MG2, CA, CA2, CL
-            } else if (resName.equalsIgnoreCase("NA") || resName.equalsIgnoreCase("K")
-                    || resName.equalsIgnoreCase("MG") || resName.equalsIgnoreCase("MG2")
-                    || resName.equalsIgnoreCase("CA") || resName.equalsIgnoreCase("CA2")
-                    || resName.equalsIgnoreCase("CL") || resName.equalsIgnoreCase("BR")
-                    || resName.equalsIgnoreCase("ZN") || resName.equalsIgnoreCase("ZN2")) {
+            } else if (isIon) {
                 ions.add(m);
                 ionHashMap.put(key, m);
             } else {

--- a/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
@@ -2479,7 +2479,7 @@ public final class PDBFilter extends SystemFilter {
             for (MSNode m : ions) {
                 Molecule ion = (Molecule) m;
                 String name = ion.getResidueName().toUpperCase();
-                HetAtoms hetatm = HetAtoms.valueOf(name);
+                HetAtoms hetatm = HetAtoms.parse(name);
                 Atom atom = ion.getAtomList().get(0);
                 if (ion.getAtomList().size() != 1) {
                     logger.severe(format(" Check residue %s of chain %s.", ion.toString(), ion.getChainID()));
@@ -5254,7 +5254,18 @@ public final class PDBFilter extends SystemFilter {
         H2O,
         WAT,
         ZN,
-        ZN2
+        ZN2;
+
+        /**
+         * Slightly more robust parsing function that ignores case and trailing numbers, -, and +
+         *
+         * @param str String to parse
+         * @return    Corresponding HetAtoms value.
+         */
+        public static HetAtoms parse(String str) {
+            String hName = str.toUpperCase().replaceFirst("[0-9+\\-]+$", "");
+            return valueOf(hName);
+        }
     }
 
 }

--- a/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
@@ -43,6 +43,7 @@ import ffx.numerics.math.VectorMath;
 import ffx.potential.MolecularAssembly;
 import ffx.potential.bonded.Atom;
 import ffx.utilities.Constants;
+import org.apache.commons.math3.util.FastMath;
 
 import java.util.Arrays;
 import java.util.logging.Logger;
@@ -107,6 +108,7 @@ public class ConvexHullOps {
         assert nVerts > 1;
         double[] vertPoints = new double[3*nVerts];
         qh.getVertices(vertPoints);
+        // TODO: Determine why it is that this works without calling the square root of dist2.
         double maxDist = IntStream.range(0, nVerts).
                 parallel().
                 mapToDouble((int i) -> {
@@ -122,6 +124,7 @@ public class ConvexHullOps {
                     return mij;
                 }).
                 max().getAsDouble();
+        maxDist = FastMath.sqrt(maxDist);
         time += System.nanoTime();
         if (time > 1E9) {
             logger.warning(String.format(" Required %12.6g sec to find max distance on a convex hull." +

--- a/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
@@ -86,6 +86,9 @@ public class ConvexHullOps {
      */
     public static QuickHull3D constructHull(Atom[] atoms) {
         int nAts = atoms.length;
+        if (nAts < 4) {
+            throw new IllegalArgumentException(String.format(" 3D convex hull ill-defined for less than 4 points, found %d", nAts));
+        }
         double[] xyz = new double[nAts * 3];
         for (int i = 0; i < nAts; i++) {
             Atom at = atoms[i];
@@ -105,7 +108,9 @@ public class ConvexHullOps {
     public static double maxDist(QuickHull3D qh) {
         long time = -System.nanoTime();
         int nVerts = qh.getNumVertices();
-        assert nVerts > 1;
+        if (nVerts < 2) {
+            return 0;
+        }
         double[] vertPoints = new double[3*nVerts];
         qh.getVertices(vertPoints);
         double maxDist = IntStream.range(0, nVerts).

--- a/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ConvexHullOps.java
@@ -108,7 +108,6 @@ public class ConvexHullOps {
         assert nVerts > 1;
         double[] vertPoints = new double[3*nVerts];
         qh.getVertices(vertPoints);
-        // TODO: Determine why it is that this works without calling the square root of dist2.
         double maxDist = IntStream.range(0, nVerts).
                 parallel().
                 mapToDouble((int i) -> {


### PR DESCRIPTION
FFX should now be robust to residue names like "ZN2+", "CL-", "CA++", etc; also several types of water residue name are recognized and converted to a standard "HOH".