### PR TITLE
Updates to the Volume JUnit Test and Default GaussVol probe radius

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GaussVol.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GaussVol.java
@@ -206,21 +206,25 @@ public class GaussVol {
      * Original value from Schnieders thesis work: 0.0327
      * Value based on testing with Schnieders thesis test set, Sept 2019: 0.11337
      */
-    private double solventPressure = 0.04800;
+    private double solventPressure = 0.04420;
     /**
      * Volume offset in Ang^3
      * Set based on comparison of FFX Volumes for small alkanes (methane-decane)
      * to Tinker Solvent-Accessible Volumes (using H and a probe of 1.4 in Tinker)
      * With a probe radius of 0.0: 27.939
      */
-    private double volumeOffsetVdwToSEV = 30.744;
+    //private double volumeOffsetVdwToSEV = 30.744;
+    //private double volumeOffsetVdwToSEV = 0.0;
+    private double volumeOffsetVdwToSEV = 28.148;
     /**
      * Surface Area offset in Ang^2
      * Set based on comparison of FFX Surface Areas for small alkanes (methane-decane)
      * to Tinker Solvent-Accessible Surface Areas (using H and a probe of 1.4 in Tinker)
      * With a probe radius of 0.0: 46.111
      */
-    private double surfaceAreaOffsetVdwToSASA = 52.885;
+    //private double surfaceAreaOffsetVdwToSASA = 52.885;
+    //private double surfaceAreaOffsetVdwToSASA = 37.529;
+    private double surfaceAreaOffsetVdwToSASA = 0.0;
     /**
      * Surface tension in kcal/mol/Ang^2.
      */

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
@@ -137,7 +137,7 @@ public class GeneralizedKirkwood implements LambdaInterface {
     /**
      * Default probe radius for use with Gaussian Volumes.
      */
-    private static final double DEFAULT_GAUSSVOL_PROBE = 1.2;
+    private static final double DEFAULT_GAUSSVOL_PROBE = 1.0;
     /**
      * Default dielectric offset
      **/

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
@@ -142,7 +142,10 @@ public class GeneralizedKirkwood implements LambdaInterface {
      * Default dielectric offset
      **/
     private static final double DEFAULT_DIELECTRIC_OFFSET = 0.09;
-
+    /**
+     * Default constant for the Generalized Kirkwood cross-term.
+     */
+    public static final double DEFAULT_GKC = 2.455;
     /**
      * Empirical scaling of the Bondi radii.
      */

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
@@ -137,7 +137,7 @@ public class GeneralizedKirkwood implements LambdaInterface {
     /**
      * Default probe radius for use with Gaussian Volumes.
      */
-    private static final double DEFAULT_GAUSSVOL_PROBE = 1.0;
+    private static final double DEFAULT_GAUSSVOL_PROBE = 1.2;
     /**
      * Default dielectric offset
      **/

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
@@ -125,7 +125,7 @@ public class GeneralizedKirkwood implements LambdaInterface {
      * <p>
      * For use with GaussVol volumes (i.e. a vdW volume), a larger solvent pressure of 0.125 is needed.
      */
-    private static final double DEFAULT_SOLVENT_PRESSURE = 0.04800;
+    private static final double DEFAULT_SOLVENT_PRESSURE = 0.04420;
 
     /**
      * Original crossover in Schnieders thesis: 3.0*(surface tension/solvent pressure)

--- a/modules/potential/src/test/java/ffx/potential/groovy/VolumeTest.java
+++ b/modules/potential/src/test/java/ffx/potential/groovy/VolumeTest.java
@@ -41,8 +41,8 @@ public class VolumeTest {
         // Evaluate the script.
         volume.run();
 
-        org.junit.Assert.assertEquals(253.86, volume.totalVolume, 0.001);
-        org.junit.Assert.assertEquals(202.187, volume.totalSurfaceArea, 0.001);
+        org.junit.Assert.assertEquals(253.864, volume.totalVolume, 0.01);
+        org.junit.Assert.assertEquals(202.187, volume.totalSurfaceArea, 0.01);
 
     }
 

--- a/modules/potential/src/test/java/ffx/potential/groovy/VolumeTest.java
+++ b/modules/potential/src/test/java/ffx/potential/groovy/VolumeTest.java
@@ -3,6 +3,7 @@ package ffx.potential.groovy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import ffx.potential.groovy.Volume;
 
 import groovy.lang.Binding;
 
@@ -40,8 +41,8 @@ public class VolumeTest {
         // Evaluate the script.
         volume.run();
 
-        org.junit.Assert.assertEquals(256.46, volume.totalVolume, 0.001);
-        org.junit.Assert.assertEquals(255.072, volume.totalSurfaceArea, 0.001);
+        org.junit.Assert.assertEquals(253.86, volume.totalVolume, 0.001);
+        org.junit.Assert.assertEquals(202.187, volume.totalSurfaceArea, 0.001);
 
     }
 
@@ -56,8 +57,8 @@ public class VolumeTest {
         // Evaluate the script
         volume.run();
 
-        org.junit.Assert.assertEquals(368.282, volume.totalVolume, 0.001);
-        org.junit.Assert.assertEquals(336.589, volume.totalSurfaceArea, 0.001);
+        org.junit.Assert.assertEquals(365.686, volume.totalVolume, 0.001);
+        org.junit.Assert.assertEquals(283.704, volume.totalSurfaceArea, 0.001);
 
     }
 


### PR DESCRIPTION
In my testing with longer nucleic acids (24+ bases), using a probe radius of 1.2 lead to an out of memory error, so I decided to keep the default at 1.0