### PR TITLE
0-padded MPI logging

### DIFF
--- a/modules/ui/src/main/java/ffx/ui/LogFormatter.java
+++ b/modules/ui/src/main/java/ffx/ui/LogFormatter.java
@@ -120,7 +120,7 @@ public class LogFormatter extends SimpleFormatter {
      */
     private String mpiFormat(int size, int rank, String[] lines) {
         int rankLen = Integer.toString(size - 1).length();
-        String formatString = " [%" + rankLen + "d]%s";
+        String formatString = " [%0" + rankLen + "d]%s";
         StringBuilder sb = new StringBuilder(String.format(formatString, rank, lines[0]));
         for (int i = 1; i < lines.length; i++) {
             sb.append("\n");


### PR DESCRIPTION
MPI formatting should now be like [0014] rather than [  14]. This is a truly extensive and complicated change, one of the most devilishly difficult I've ever pushed.