### PR TITLE
It is entirely plausible that MELD will be applied without force fiel…

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
@@ -1637,7 +1637,8 @@ public class ForceFieldEnergyOpenMM extends ForceFieldEnergy {
          * A negative value indicates we're not using MELD.
          */
         private boolean useMeld;
-        private double meldScaleFactor = -1.0;
+        private static final double DEFAULT_MELD_SCALE_FACTOR = -1.0;
+        private final double meldScaleFactor;
 
         OpenMMSystem(MolecularAssembly molecularAssembly) {
             // Create the OpenMM System
@@ -1678,8 +1679,8 @@ public class ForceFieldEnergyOpenMM extends ForceFieldEnergy {
             }
 
             // Check for MELD use. If we're using MELD, set all lambda terms to true.
-            meldScaleFactor = forceField.getDouble("MELD_SCALE_FACTOR", meldScaleFactor);
-            if (meldScaleFactor < 1.0 && meldScaleFactor > 0.0) {
+            meldScaleFactor = forceField.getDouble("MELD_SCALE_FACTOR", DEFAULT_MELD_SCALE_FACTOR);
+            if (meldScaleFactor <= 1.0 && meldScaleFactor > 0.0) {
                 useMeld = true;
                 elecLambdaTerm = true;
                 vdwLambdaTerm = true;


### PR DESCRIPTION
…d scaling, so the check at line 1682 needs to include 1.0. Also, meldScaleFactor is a poor name for force field scaling, especially seeing as that the notion of scaling the entire force field is not part of MELD, not exclusive to MELD and has been applied outside of MELD. Nor do I feel that setting force field scaling should imply MELD is in use.

I know we only foresee use of the flag with MELD, but at some point, somebody is going to want to scale the force field independent of MELD, and it would help not to have the mechanisms intertwined. This is how we get problems like RotamerOptimization going for 10,000+ lines of code.

Note: most of this complaint is about the code surrounding the fix (e.g. the whole concept of meldScaleFactor to do FF scaling), not about the bug itself, which is pretty minor, easy to miss, and easy to fix.