### PR TITLE
MC-OST: validity check on thermostat/integrator and writing of error snapshots

### DIFF
--- a/modules/algorithms/src/main/java/ffx/algorithms/cli/DynamicsOptions.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/cli/DynamicsOptions.java
@@ -257,4 +257,12 @@ public class DynamicsOptions {
     public boolean getOptimize() {
         return optimize;
     }
+
+    /**
+     * Re-sets the thermostat; intended for MC-OST going to ADIABATIC.
+     * @param thermo Thermostat to replace the requested one with.
+     */
+    public void setThermostat(ThermostatEnum thermo) {
+        thermostat = thermo;
+    }
 }

--- a/modules/algorithms/src/main/java/ffx/algorithms/dynamics/MolecularDynamics.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/dynamics/MolecularDynamics.java
@@ -1455,7 +1455,7 @@ public class MolecularDynamics implements Runnable, Terminatable {
      * Performs the inner loop of writing snapshots to disk; used by both
      * detectAtypicalEnergy and a try-catch in dynamics.
      */
-    private void writeStoredSnapshots() {
+    public void writeStoredSnapshots() {
         int numSnaps = lastSnapshots.size();
 
         File origFile = molecularAssembly.getFile();

--- a/modules/algorithms/src/main/java/ffx/algorithms/dynamics/integrators/IntegratorEnum.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/dynamics/integrators/IntegratorEnum.java
@@ -44,7 +44,17 @@ package ffx.algorithms.dynamics.integrators;
  */
 public enum IntegratorEnum {
 
-    BEEMAN, RESPA, STOCHASTIC, VELOCITYVERLET, VERLET
+    BEEMAN(false, true), RESPA(true, true),
+    STOCHASTIC(false, false), VELOCITYVERLET(true, true),
+    VERLET(true, true);
+
+    public final boolean knownReversible;
+    public final boolean knownDeterministic;
+
+    IntegratorEnum(boolean reversible, boolean deterministic) {
+        knownReversible = reversible;
+        knownDeterministic = deterministic;
+    }
 }
 
 

--- a/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
@@ -252,6 +252,13 @@ public class MDMove implements MCMove {
     }
 
     /**
+     * Triggers MD to write out its stored snapshots in case of error.
+     */
+    public void writeErrorFiles() {
+        molecularDynamics.writeStoredSnapshots();
+    }
+
+    /**
      * Get the total energy change for the current move.
      *
      * @return Total energy change.

--- a/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/mc/MDMove.java
@@ -37,6 +37,7 @@
 //******************************************************************************
 package ffx.algorithms.mc;
 
+import java.util.EnumSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.lang.Math.abs;
@@ -272,7 +273,7 @@ public class MDMove implements MCMove {
      *
      * @param mdStep MD step (not MC cycle number) to write files (if any) for.
      */
-    public void writeFilesForStep(long mdStep) {
-        molecularDynamics.writeFilesForStep(mdStep);
+    public EnumSet<MolecularDynamics.WriteActions> writeFilesForStep(long mdStep) {
+        return molecularDynamics.writeFilesForStep(mdStep);
     }
 }

--- a/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/MonteCarloOST.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/MonteCarloOST.java
@@ -567,6 +567,7 @@ public class MonteCarloOST extends BoltzmannMC {
                 proposedOSTEnergy = orthogonalSpaceTempering.energyAndGradient(proposedCoordinates, gradient);
             } catch (EnergyException e) {
                 mdMove.revertMove();
+                mdMove.writeErrorFiles();
                 if (!equilibration) {
                     lambdaMove.revertMove();
                     lambda = currentLambda;

--- a/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/MonteCarloOST.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/MonteCarloOST.java
@@ -37,6 +37,7 @@
 //******************************************************************************
 package ffx.algorithms.thermodynamics;
 
+import java.util.EnumSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.lang.String.format;
@@ -665,7 +666,10 @@ public class MonteCarloOST extends BoltzmannMC {
 
                 if (lambda >= orthogonalSpaceTempering.lambdaWriteOut) {
                     long mdMoveNum = imove * stepsPerMove;
-                    mdMove.writeFilesForStep(mdMoveNum);
+                    EnumSet<MolecularDynamics.WriteActions> written = mdMove.writeFilesForStep(mdMoveNum);
+                    if (written.contains(MolecularDynamics.WriteActions.RESTART)) {
+                        orthogonalSpaceTempering.writeAdditionalRestartInfo(false);
+                    }
                 }
             }
 

--- a/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/OrthogonalSpaceTempering.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/thermodynamics/OrthogonalSpaceTempering.java
@@ -482,9 +482,11 @@ public class OrthogonalSpaceTempering implements CrystalPotential, LambdaInterfa
     }
 
     @Override
-    public void writeAdditionalRestartInfo() {
-        potential.writeAdditionalRestartInfo();
+    public void writeAdditionalRestartInfo(boolean recursive) {
         writeRestart();
+        if (recursive) {
+            potential.writeAdditionalRestartInfo(true);
+        }
     }
 
     /**

--- a/modules/numerics/src/main/java/ffx/numerics/Potential.java
+++ b/modules/numerics/src/main/java/ffx/numerics/Potential.java
@@ -307,8 +307,13 @@ public interface Potential {
 
     /**
      * Writes additional restart information, if any (e.g. OST histogram and lambda restart files).
+     * The recursive flag should generally only be true for the top-level Potential called.
+     *
+     * @param recursive Whether to have all underlying Potentials write additional restart info.
      */
-    default void writeAdditionalRestartInfo() {
-        getUnderlyingPotentials().forEach(Potential::writeAdditionalRestartInfo);
+    default void writeAdditionalRestartInfo(boolean recursive) {
+        if (recursive) {
+            getUnderlyingPotentials().forEach((Potential p) -> p.writeAdditionalRestartInfo(false));
+        } // Else, no-op.
     }
 }


### PR DESCRIPTION
This both makes MC-OST check the validity of the thermostat/integrator passed to it (correcting thermostat to ADIABATIC, throwing an exception if the integrator is incorrect), and lets it write error snapshots stored by MolecularDynamics if any exist.

I figure that anybody who really needs to try MC-OST without reversible, deterministic NVE dynamics is going to be savvy enough to comment out the checks involved and recompile.