### PR TITLE
Updates to handling of xyz/arc files to correspond with recent updates to the superpose script.

### DIFF
--- a/modules/potential/src/main/groovy/ffx/potential/groovy/Superpose.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/Superpose.groovy
@@ -300,6 +300,7 @@ class Superpose extends PotentialScript {
 
       // Check which molecular assemblies to do RMSD comparisons among.
       if (!frameComparison) {
+        // Do one vs. all comparison.
         if (dRMSD) {
           logger.info(format("\n Coordinate RMSD\n Snapshots      Original  After Translation  After Rotation    dRMSD"))
         } else if (verbose) {
@@ -314,6 +315,8 @@ class Superpose extends PotentialScript {
           // The systemFilter is from the 2nd file read in, which could have multiple models.
           trajectoryRMSD(systemFilter, nUsed, usedIndices, x, x2, xUsed, x2Used, massUsed, 0)
         }
+      } else if (filenames.size() >= 2 && frameComparison){
+          logger.severe("\n Cannot perform all versus all superposition (-A) with two different model files. Please choose one versus all when using two model files.")
       } else {
         // Do the all vs. all comparison.
         if (storeMatrix) {

--- a/modules/potential/src/main/java/ffx/potential/parsers/XYZFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/XYZFilter.java
@@ -526,7 +526,7 @@ public class XYZFilter extends SystemFilter {
       Atom[] atoms = activeMolecularAssembly.getAtomArray();
       int nSystem = atoms.length;
 
-      if (bufferedReader == null || resetPosition) {
+      if (bufferedReader == null && !resetPosition) {
         bufferedReader = new BufferedReader(new FileReader(currentFile));
         // Read past the first N + 1 lines that begin with an integer.
         for (int i = 0; i < nSystem + 1; i++) {
@@ -536,6 +536,10 @@ public class XYZFilter extends SystemFilter {
           }
         }
         snapShot = 1;
+      } else if (resetPosition){
+        //Reset the reader to the beginning of the file. Do not skip reading the first entry if resetPostion is true.
+        bufferedReader = new BufferedReader(new FileReader(currentFile));
+        snapShot = 0;
       }
 
       snapShot++;


### PR DESCRIPTION
I added functionality for SaveAsXYZ to be able to create an arc file from a multiple model PDB and I updated the readNext method in XYZFilter so that when resetPosition is true, the readNext function begins reading the model file at the first model rather than at the second model (as was previously implemented). I also added a severe warning to the superpose script in case users try to do all versus all RMSDs with two different files (right now we only have all versus all RMSDs implemented for a single multiple model file).