### PR TITLE
Updated GeneralizedKirkwood to reflect new GK implicit solvent defaults

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/GeneralizedKirkwood.java
@@ -346,8 +346,8 @@ public class GeneralizedKirkwood implements LambdaInterface {
     // Define default Bondi scale factor, and HCT overlap scale factors.
     bondiScale = forceField.getDouble("SOLUTE_SCALE", DEFAULT_SOLUTE_SCALE);
     gkOverlapScale = forceField.getDouble("HCT_SCALE", DEFAULT_HCT_SCALE);
-    descreenWithVDW = forceField.getBoolean("DESCREEN_VDW", false);
-    descreenWithHydrogen = forceField.getBoolean("DESCREEN_HYDROGEN", true);
+    descreenWithVDW = forceField.getBoolean("DESCREEN_VDW", true);
+    descreenWithHydrogen = forceField.getBoolean("DESCREEN_HYDROGEN", false);
     if (descreenWithVDW && !descreenWithHydrogen) {
       perfectHCTScale = forceField.getBoolean("PERFECT_HCT_SCALE", false);
     } else {
@@ -518,7 +518,7 @@ public class GeneralizedKirkwood implements LambdaInterface {
     logger.info(format("   Descreen with Hydrogen Atoms:       %8B", descreenWithHydrogen));
     logger.info(format("   Use Neck Correction:                %8B", neckCorrection));
     logger.info(format("   GaussVol HCT Scale Factors:         %8B", perfectHCTScale));
-    logger.info(format("   HCT Scale Factor:                   %8.4f",forceField.getDouble("HCT-SCALE",0.00)));
+    logger.info(format("   HCT Scale Factor:                   %8.4f",forceField.getDouble("HCT-SCALE",DEFAULT_HCT_SCALE)));
     logger.info(format("   GKC:                                %8.3f",forceField.getDouble("GKC",DEFAULT_GKC)));
     SoluteRadii.logRadiiSource(forceField);
     logger.info(

--- a/modules/potential/src/test/java/ffx/potential/groovy/EnergyTest.java
+++ b/modules/potential/src/test/java/ffx/potential/groovy/EnergyTest.java
@@ -297,7 +297,7 @@ public class EnergyTest extends PotentialTest {
                 2290,
                 0.0,
                 2290,
-                -157.8978447444496,
+                -183.2685758293095,
                 2556,
                 true
             },
@@ -361,7 +361,7 @@ public class EnergyTest extends PotentialTest {
                 2290,
                 -25.85878386,
                 2290,
-                -190.15196400147826,
+                -207.47535790184864,
                 2556,
                 true
             },
@@ -393,7 +393,7 @@ public class EnergyTest extends PotentialTest {
                 748,
                 -8.62910979,
                 748,
-                -55.771821575687085,
+                -62.58502136469313,
                 903,
                 false
             },


### PR DESCRIPTION
0.72 HCT scale, 2.455 GKC, descreening with vdW radii and not descreening with hydrogens. Default cav model was left as gauss-disp instead of sev-disp in anticipation of using the implicit solvent model with proteins/nucleic acids.