### PR TITLE
Added Acidostat and Fmod bias energies to RotOp search over titratable sites.

### DIFF
--- a/modules/algorithms/src/main/java/ffx/algorithms/cli/ManyBodyOptions.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/cli/ManyBodyOptions.java
@@ -195,8 +195,9 @@ public class ManyBodyOptions {
     }
     TitrationUtils titrationUtils = null;
     if (titrate) {
-      logger.info(" Turing on ASP, GLU, LYS and HIS titration rotamers.");
+      logger.info(" Turning on ASP, GLU, LYS and HIS titration rotamers.");
       titrationUtils = new TitrationUtils(activeAssembly.getForceField());
+      titrationUtils.setRotamerPhBias(298.15, 7.4);
       List<Residue> residues = activeAssembly.getResidueList();
       for (Residue residue : residues) {
         residue.setTitrationUtils(titrationUtils);

--- a/modules/algorithms/src/main/java/ffx/algorithms/optimize/manybody/EnergyExpansion.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/optimize/manybody/EnergyExpansion.java
@@ -44,10 +44,7 @@ import ffx.algorithms.optimize.RotamerOptimization;
 import ffx.numerics.Potential;
 import ffx.potential.ForceFieldEnergyOpenMM;
 import ffx.potential.MolecularAssembly;
-import ffx.potential.bonded.Atom;
-import ffx.potential.bonded.Residue;
-import ffx.potential.bonded.Rotamer;
-import ffx.potential.bonded.RotamerLibrary;
+import ffx.potential.bonded.*;
 import ffx.potential.utils.EnergyException;
 import java.io.File;
 import java.io.IOException;
@@ -689,6 +686,14 @@ public class EnergyExpansion {
       }
     } finally {
       rO.turnOffResidue(residues[i]);
+    }
+
+    Rotamer[] rotamers = residues[i].getRotamers(library);
+
+    if (rotamers[ri].isTitrating){
+      logger.info(residues[i].getName());
+       double bias = rotamers[ri].getRotamerPhBias();
+       energy += bias;
     }
 
     return energy;

--- a/modules/potential/src/main/java/ffx/potential/bonded/Residue.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/Residue.java
@@ -374,6 +374,10 @@ public class Residue extends MSGroup implements Comparable<Residue> {
     this.titrationUtils = titrationUtils;
   }
 
+  public TitrationUtils getTitrationUtils(){
+    return titrationUtils;
+  }
+
   /**
    * getAminoAcid3.
    *

--- a/modules/potential/src/main/java/ffx/potential/bonded/Rotamer.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/Rotamer.java
@@ -330,4 +330,8 @@ public class Rotamer {
       return "";
     }
   }
+
+  public double getRotamerPhBias(){
+    return titrationUtils.getRotamerPhBias(aminoAcid3);
+  }
 }


### PR DESCRIPTION
The reference Fmod energies for the titratable sites are not yet final and will be updated with future simulation data.