### PR TITLE
Updated CIFtoXYZ to handle alternative space groups.

### DIFF
--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
@@ -7876,7 +7876,7 @@ public class SpaceGroupDefinitions {
    */
   static SpaceGroup getAlternativeSpaceGroup(String name) {
     SpaceGroup spaceGroup = null;
-    if (name.equalsIgnoreCase("P21/a")) {
+    if (name.equalsIgnoreCase("P21/a") || name.equalsIgnoreCase("P 1 21/a 1")) {
       spaceGroup =
           new SpaceGroup(
               14,
@@ -7894,7 +7894,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_mX_mY_Z, SymOp.Tr_12_0_12),
               new SymOp(SymOp.Rot_mX_mY_mZ, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_X_Y_mZ, SymOp.Tr_12_0_12));
-    } else if (name.equalsIgnoreCase("P21/n")) {
+    } else if (name.equalsIgnoreCase("P21/n") || name.equalsIgnoreCase("P 1 21/n 1")) {
       spaceGroup =
               new SpaceGroup(
                       14,
@@ -7912,7 +7912,7 @@ public class SpaceGroupDefinitions {
                       new SymOp(SymOp.Rot_mX_Y_mZ, SymOp.Tr_12_12_12),
                       new SymOp(SymOp.Rot_mX_mY_mZ, SymOp.Tr_0_0_0),
                       new SymOp(SymOp.Rot_X_mY_Z, SymOp.Tr_12_12_12));
-    } else if (name.equalsIgnoreCase("R3")) {
+    } else if (name.equalsIgnoreCase("R3") || name.equalsIgnoreCase("R 3")) {
       spaceGroup =
           new SpaceGroup(
               146,
@@ -7929,7 +7929,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_X_Y_Z, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_Z_X_Y, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_Y_Z_X, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R-3")) {
+    } else if (name.equalsIgnoreCase("R-3") || name.equalsIgnoreCase("R -3")) {
       spaceGroup =
           new SpaceGroup(
               148,
@@ -7949,7 +7949,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_mX_mY_mZ, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_mZ_mX_mY, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_mY_mZ_mX, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R32")) {
+    } else if (name.equalsIgnoreCase("R32")  || name.equalsIgnoreCase("R 3 2")) {
       spaceGroup =
           new SpaceGroup(
               155,
@@ -7969,7 +7969,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_mY_mX_mZ, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_mZ_mY_mX, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_mX_mZ_mY, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R3m")) {
+    } else if (name.equalsIgnoreCase("R3m")  || name.equalsIgnoreCase("R 3 m")) {
       spaceGroup =
           new SpaceGroup(
               160,
@@ -7989,7 +7989,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_Y_X_Z, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_Z_Y_X, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_X_Z_Y, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R3c")) {
+    } else if (name.equalsIgnoreCase("R3c")  || name.equalsIgnoreCase("R 3 c")) {
       spaceGroup =
           new SpaceGroup(
               161,
@@ -8009,7 +8009,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_Y_X_Z, SymOp.Tr_12_12_12),
               new SymOp(SymOp.Rot_Z_Y_X, SymOp.Tr_12_12_12),
               new SymOp(SymOp.Rot_X_Z_Y, SymOp.Tr_12_12_12));
-    } else if (name.equalsIgnoreCase("R-3m")) {
+    } else if (name.equalsIgnoreCase("R-3m")  || name.equalsIgnoreCase("R -3 2/m")) {
       spaceGroup =
           new SpaceGroup(
               166,
@@ -8035,7 +8035,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_Y_X_Z, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_Z_Y_X, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_X_Z_Y, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R-3c")) {
+    } else if (name.equalsIgnoreCase("R-3c") || name.equalsIgnoreCase("R -3 2/c")) {
       spaceGroup =
           new SpaceGroup(
               167,

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
@@ -177,6 +177,7 @@ class CIFtoXYZ extends PotentialScript {
       if (symmetry.spaceGroupNameH_M.rowCount > 0) {
         sgName = symmetry.spaceGroupNameH_M.get(0)
         logger.info(format(" CIF Hermann–Mauguin Space Group: %s", sgName))
+        sgName = sgName.replaceAll(" +", "")
       }
     } else {
       if (sgNum != -1) {
@@ -187,10 +188,12 @@ class CIFtoXYZ extends PotentialScript {
     }
 
     SpaceGroup sg
-    if (sgNum != -1) {
+    logger.info(" SGNAME: " + sgName)
+    sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
+    logger.info(" Short Name: " + sg.shortName)
+    logger.info(" PDB Name: " + sg.pdbName)
+    if (sg == null) {
       sg = SpaceGroupDefinitions.spaceGroupFactory(sgNum)
-    } else {
-      sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
     }
 
     // Fall back to P1.
@@ -208,6 +211,7 @@ class CIFtoXYZ extends PotentialScript {
     double gamma = cell.angleGamma.get(0)
 
     Crystal crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
+    logger.info(" NEW XTAL INFO:")
     logger.info(crystal.toString())
 
     AtomSite atomSite = firstBlock.atomSite


### PR DESCRIPTION
I had forgotten to check for PDB formatted names when obtaining alternative space groups with the getAlternativeSpaceGroup method, therefore I updated the method within SpaceGroupDefinitions. 

Additionally, CIFtoXYZ.groovy prioritized space group number rather than space group name. This lead to some confusion when handling alternative space groups (_e.g._ P21/a, P21/c, and P21/n are all space group number 14). I believe CIFtoXYZ should now correctly specify alternative space groups in the created properties file.