### PR TITLE
Crystallographic code update associated with Z' > 1 and conversion of CIF files.

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -40,7 +40,6 @@ package ffx.algorithms.groovy
 import ffx.algorithms.cli.AlgorithmsScript
 import ffx.numerics.math.RunningStatistics
 import ffx.potential.MolecularAssembly
-import ffx.potential.bonded.Atom
 import ffx.potential.cli.AtomSelectionOptions
 import ffx.potential.parsers.SystemFilter
 import ffx.potential.utils.ProgressiveAlignmentOfCrystals
@@ -49,7 +48,6 @@ import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 
-import static java.lang.String.format
 import static org.apache.commons.io.FilenameUtils.concat
 import static org.apache.commons.io.FilenameUtils.getBaseName
 import static org.apache.commons.io.FilenameUtils.getFullPath
@@ -59,9 +57,9 @@ import static org.apache.commons.io.FilenameUtils.getFullPath
  * This script is based off of the PACCOM code created by Okimasa Okada.
  *
  * @author Okimasa OKADA
- * @author Aaron J. Nessler and Michael J. Schnieders
  * created by Okimasa OKADA 2017/3/31
  * revised by Okimasa OKADA 2019/2/25
+ * @author Aaron J. Nessler and Michael J. Schnieders
  * ported to FFX by Aaron Nessler and Micheal Schnieders 2020
  * revised by Aaron Nessler and Michael Schnieders 2021
  * <br>
@@ -69,7 +67,8 @@ import static org.apache.commons.io.FilenameUtils.getFullPath
  * <br>
  * ffxc test.SuperposeCrystals &lt;filename&gt &lt;filename&gt;
  */
-@Command(description = " Compare crystal polymorphs based on a RMSD of aligned crystal coordinates.", name = "ffxc SuperposeCrystals")
+@Command(description = " Determine the RMSD for crystal polymorphs using the Progressive Alignment of Crystals (PAC) algorithm.",
+        name = "ffxc SuperposeCrystals")
 class SuperposeCrystals extends AlgorithmsScript {
 
   @Mixin
@@ -79,7 +78,7 @@ class SuperposeCrystals extends AlgorithmsScript {
    * --na or --numAU Number of asymmetric units to include from each crystal in RMSD comparison.
    */
   @Option(names = ['--na', '--numAU'], paramLabel = '20', defaultValue = '20',
-      description = 'Set the number of asymmetric units to include in final PAC RMSD.')
+      description = 'Set the number of asymmetric units to include in final RMSD.')
   int numAU
 
   /**
@@ -90,45 +89,45 @@ class SuperposeCrystals extends AlgorithmsScript {
   int numInflatedAU
 
   /**
-   * --ns or --numSearch Number of molecules for each handedness in the first crystal.
+   * --ns or --numSearch Number of asymmetric units for each handedness in the first crystal.
    */
-  @Option(names = ['--ns', '--numSearch'], paramLabel = '3', defaultValue = '3',
-      description = 'Set the number of asymmetric units to search in the 1st crystal to check for mirrored conformations.')
+  @Option(names = ['--ns', '--numSearch'], paramLabel = '1', defaultValue = '1',
+      description = 'Set the number of asymmetric units to search in the 1st crystal to check for additional conformations.')
   int numSearch
 
   /**
-   * --ns2 or --numSearch2 Number of molecules for each handedness in the second crystal.
+   * --ns2 or --numSearch2 Number asymmetric units for each handedness in the second crystal.
    */
-  @Option(names = ['--ns2', '--numSearch2'], paramLabel = '3', defaultValue = '3',
-      description = 'Set the number of asymmetric units to search in the 2nd crystal to check for mirrored conformations.')
+  @Option(names = ['--ns2', '--numSearch2'], paramLabel = '1', defaultValue = '1',
+      description = 'Set the number of asymmetric units to search in the 2nd crystal to check for additional conformations.')
   int numSearch2
 
   /**
-   * --zp or --zPrime Overrides number of molecules in the asymmetric unit.
+   * --zp or --zPrime Overrides number of species in the asymmetric unit.
    */
   @Option(names = ['--zp', '--zPrime'], paramLabel = '-1', defaultValue = '-1',
-          description = 'Number of species in asymmetric unit should be detected by default (Z\'). This flag should only be used if the default detection fails.')
+          description = 'Number of species in asymmetric unit of first crystal.')
   int zPrime
 
   /**
-   * --nms or --noMirrorSearch Do not loop over asymmetric units to check for mirrored conformations.
+   * --zp2 or --zPrime2 Overrides number of species in the asymmetric unit.
    */
-  @Option(names = ['--nms', '--noMirrorSearch'], paramLabel = "false", defaultValue = "false",
-      description = 'Do not loop over asymmetric units to check for mirrored conformations.')
-  private static boolean noMirrorSearch
+  @Option(names = ['--zp2', '--zPrime2'], paramLabel = '-1', defaultValue = '-1',
+          description = 'Number of species in asymmetric unit of second crystal.')
+  int zPrime2
 
   /**
-   * -w or --write Write out the PAC RMSD matrix.
+   * -w or --write Write out the RMSD matrix.
    */
   @Option(names = ['-w', '--write'], paramLabel = "false", defaultValue = "false",
-      description = 'Write out the PAC RMSD matrix.')
+      description = 'Write out the RMSD matrix.')
   private static boolean write
 
   /**
-   * -r or --restart Attempt to restart from a previously written PAC RMSD matrix.
+   * -r or --restart Attempt to restart from a previously written RMSD matrix.
    */
   @Option(names = ['-r', '--restart'], paramLabel = "false", defaultValue = "false",
-      description = 'Attempt to restart from a previously written PAC RMSD matrix.')
+      description = 'Attempt to restart from a previously written RMSD matrix.')
   private static boolean restart
 
   /**
@@ -139,33 +138,25 @@ class SuperposeCrystals extends AlgorithmsScript {
   private static boolean savePDB
 
   /**
-   * -f or --full Perform the full comparison (takes considerably longer, but more information returned).
+   * --ex or --exhaustive Perform an exhaustive comparison to handle multiple conformations (more expensive, but may find lower RMSD).
    */
-  @Option(names = ['-f', '--full'], paramLabel = "false", defaultValue = "false",
-      description = 'Use the full number of comparisons (tradeoff between speed and information returned).')
-  private static boolean full
+  @Option(names = ['--ex', '--exhaustive'], paramLabel = "false", defaultValue = "false",
+      description = 'Perform an exhaustive comparison to handle multiple conformations (more expensive, but may find lower RMSD).')
+  private static boolean exhaustive
 
   /**
-   * --ac or --alphaCarbons PAC RMSD will only include alpha carbons.
+   * --ac or --alphaCarbons Protein RMSD will only include alpha carbons.
    */
   @Option(names = ['--ac', '--alphaCarbons'], paramLabel = "false", defaultValue = "false",
-          description = 'PAC RMSD will only include alpha carbons.')
+          description = 'Protein RMSD will only include alpha carbons for comparison.')
   private static boolean alphaCarbons
 
   /**
-   * --nh or --noHydrogen PAC RMSD will not include hydrogen atoms.
+   * --nh or --noHydrogen RMSD will not include hydrogen atoms.
    */
   @Option(names = ['--nh', '--noHydrogen'], paramLabel = "false", defaultValue = "false",
-      description = 'PAC RMSD will not include hydrogen atoms.')
+      description = 'RMSD will not include hydrogen atoms.')
   private static boolean noHydrogen
-
-  // TODO finish implementing symmetric flag.
-  /**
-   * --sym or --symmetric Enforce generation of a symmetric PAC RMSD matrix.
-   */
-  @Option(names = ['--sym', '--symmetric'], paramLabel = "false", defaultValue = "false",
-      description = 'Enforce generation of a symmetric PAC RMSD matrix.')
-  private static boolean symmetric
 
   /**
    * --sa or --saveAres Save out PDB in ARES input format.
@@ -252,50 +243,10 @@ class SuperposeCrystals extends AlgorithmsScript {
       targetFilter = algorithmFunctions.getFilter()
     }
 
-    // Atom array from the 1st assembly.
-    Atom[] baseAtoms = activeAssembly.getAtomArray()
-    int nAtoms = baseAtoms.size()
-
-    // Collect selected atoms.
-    ArrayList<Integer> atomList = new ArrayList<>()
-    for (int i = 0; i < nAtoms; i++) {
-      Atom atom = baseAtoms[i]
-      if (atom.isActive()) {
-        String atomName = atom.getName()
-        int atomAtNum = atom.getAtomicNumber()
-        boolean proteinCheck = atomName == "CA" && atomAtNum == 6
-        boolean aminoCheck = (atomName == "N1" || atomName == "N9") && atomAtNum == 7
-        if(alphaCarbons){
-          if(proteinCheck||aminoCheck){
-            atomList.add(i)
-          }
-        }else if (!noHydrogen || !atom.isHydrogen()) {
-          atomList.add(i)
-        }
-      }
-      // Reset all atoms to active once the selection is recorded.
-      atom.setActive(true)
-    }
-
-    if (atomList.size() < 1) {
-      logger.info("\n No atoms were selected for the PAC RMSD.")
-      return this
-    }
-
-    // Number of atoms included in the PAC RMSD.
-    int nPACAtoms = atomList.size()
-    logger.info(format("\n %d atoms will be used for the PAC RMSD out of %d.\n", nPACAtoms, nAtoms))
-
-    // If search is desired ensure inner loop will be used. Else use single comparison.
-    if (noMirrorSearch) {
-      numSearch = 1
-      numSearch2 = 1
-    }
-
     // Compare structures in baseFilter and targetFilter.
     ProgressiveAlignmentOfCrystals pac = new ProgressiveAlignmentOfCrystals(baseFilter, targetFilter, isSymmetric)
 
-    // Define the filename to use for the PAC RMSD values.
+    // Define the filename to use for the RMSD values.
     String filename = filenames.get(0)
     String pacFilename = concat(getFullPath(filename), getBaseName(filename) + ".txt")
 
@@ -304,8 +255,8 @@ class SuperposeCrystals extends AlgorithmsScript {
       savePDB = true
     }
 
-    runningStatistics = pac.comparisons(atomList, numAU, numInflatedAU,
-        numSearch, numSearch2, zPrime, full, savePDB, restart, write, ares, pacFilename)
+    runningStatistics = pac.comparisons(numAU, numInflatedAU, numSearch, numSearch2, zPrime, zPrime2, alphaCarbons,
+        noHydrogen, exhaustive, savePDB, restart, write, ares, pacFilename)
 
     return this
   }

--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/ProgressiveAlignmentTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/ProgressiveAlignmentTest.java
@@ -142,7 +142,7 @@ public class ProgressiveAlignmentTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.1512836, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.15354157, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   @Test

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
@@ -47,6 +47,7 @@ import ffx.potential.bonded.Atom
 import ffx.potential.bonded.Bond
 import ffx.potential.cli.PotentialScript
 import ffx.potential.parameters.ForceField
+
 import org.apache.commons.io.FilenameUtils
 import org.openscience.cdk.AtomContainer
 import org.openscience.cdk.config.AtomTypeFactory
@@ -73,6 +74,9 @@ import java.nio.file.Paths
 import static ffx.numerics.math.DoubleMath.dihedralAngle
 import static ffx.potential.bonded.BondedUtils.intxyz
 import static ffx.potential.parsers.PDBFilter.toPDBAtomLine
+import static ffx.potential.parsers.SystemFilter.setVersioning
+import static ffx.potential.parsers.SystemFilter.Versioning.PREFIX
+import static ffx.potential.parsers.SystemFilter.version
 import static java.lang.String.format
 import static org.openscience.cdk.tools.periodictable.PeriodicTable.getSymbol
 
@@ -139,6 +143,7 @@ class CIFtoXYZ extends PotentialScript {
       return this
     }
 
+    //TODO support concatenated CIF files (separated by "data_######").
     CifCoreFile cifFile
     Path path
     if (filenames != null && filenames.size() == 2) {
@@ -152,367 +157,388 @@ class CIFtoXYZ extends PotentialScript {
     String modelFilename = path.toAbsolutePath().toString()
     logger.info("\n Opening CIF file " + path)
 
-    CifCoreBlock firstBlock = cifFile.firstBlock
+//    CifCoreBlock block = cifFile.firstBlock
+    for(CifCoreBlock block: cifFile.blocks) {
+      logger.info(format(" Number of Blocks: %d", cifFile.blocks.size()))
 
-    Chemical chemical = firstBlock.chemical
-    Column nameCommon = chemical.nameCommon
-    Column nameSystematic = chemical.nameSystematic
-    int rowCount = nameCommon.rowCount
-    if (rowCount > 1) {
-      logger.info(" Chemical components")
-      for (int i = 0; i < rowCount; i++) {
-        logger.info(format("  %s", nameCommon.get(i)))
+      Chemical chemical = block.chemical
+      Column nameCommon = chemical.nameCommon
+      Column nameSystematic = chemical.nameSystematic
+      int rowCount = nameCommon.rowCount
+      if (rowCount > 1) {
+        logger.info(" Chemical components")
+        for (int i = 0; i < rowCount; i++) {
+          logger.info(format("  %s", nameCommon.get(i)))
+        }
+      } else if (rowCount > 0) {
+        logger.info(format(" Chemical component: %s", nameCommon.get(0)))
       }
-    } else if (rowCount > 0) {
-      logger.info(format(" Chemical component: %s", nameCommon.get(0)))
-    }
 
-    // Determine the space group.
-    Symmetry symmetry = firstBlock.symmetry
-    if (sgNum == -1 && sgName == "") {
-      if (symmetry.intTablesNumber.rowCount > 0) {
-        sgNum = symmetry.intTablesNumber.get(0)
-        logger.info(format(" CIF International Tables Number: %d", sgNum))
-      }
-      if (symmetry.spaceGroupNameH_M.rowCount > 0) {
-        sgName = symmetry.spaceGroupNameH_M.get(0)
-        logger.info(format(" CIF Hermann–Mauguin Space Group: %s", sgName))
-      }
-    } else {
-      if (sgNum != -1) {
-        logger.info(format(" Command line International Tables Number: %d", sgNum))
+      // Determine the space group.
+      Symmetry symmetry = block.symmetry
+      if (sgNum == -1 && sgName == "") {
+        if (symmetry.intTablesNumber.rowCount > 0) {
+          sgNum = symmetry.intTablesNumber.get(0)
+          logger.info(format(" CIF International Tables Number: %d", sgNum))
+        }
+        if (symmetry.spaceGroupNameH_M.rowCount > 0) {
+          sgName = symmetry.spaceGroupNameH_M.get(0)
+          logger.info(format(" CIF Hermann–Mauguin Space Group: %s", sgName))
+        }
       } else {
-        logger.info(format(" Command line space group name: %s", sgName))
-      }
-    }
-
-    SpaceGroup sg
-    sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
-    if (sg == null) {
-      sg = SpaceGroupDefinitions.spaceGroupFactory(sgNum)
-    }
-
-    // Fall back to P1.
-    if (sg == null) {
-      logger.warning(" The space group could not be determined from the CIF file (using P1).")
-      sg = SpaceGroupDefinitions.spaceGroupFactory(1)
-    }
-
-    Cell cell = firstBlock.cell
-    double a = cell.lengthA.get(0)
-    double b = cell.lengthB.get(0)
-    double c = cell.lengthC.get(0)
-    double alpha = cell.angleAlpha.get(0)
-    double beta = cell.angleBeta.get(0)
-    double gamma = cell.angleGamma.get(0)
-
-    Crystal crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
-    logger.info(" New crystal:")
-    logger.info(crystal.toString())
-
-    AtomSite atomSite = firstBlock.atomSite
-    Column label = atomSite.label
-    Column typeSymbol = atomSite.typeSymbol
-    Column fractX = atomSite.fractX
-    Column fractY = atomSite.fractY
-    Column fractZ = atomSite.fractZ
-
-    int nAtoms = label.getRowCount()
-    logger.info(format("\n Number of atoms: %d", nAtoms))
-    Atom[] atoms = new Atom[nAtoms]
-
-    // Define per atom information for the PDB file.
-    String resName = "CIF"
-    int resID = 1
-    double occupancy = 1.0
-    double bfactor = 1.0
-    char altLoc = ' '
-    char chain = 'A'
-    String segID = "A"
-    String[] symbols = new String[nAtoms]
-
-    // Loop over atoms.
-    for (int i = 0; i < nAtoms; i++) {
-      symbols[i] = typeSymbol.get(i)
-      double x = fractX.get(i)
-      double y = fractY.get(i)
-      double z = fractZ.get(i)
-      double[] xyz = [x, y, z]
-      crystal.toCartesianCoordinates(xyz, xyz)
-      atoms[i] = new Atom(i + 1, label.get(i), altLoc, xyz, resName, resID, chain, occupancy,
-          bfactor, segID)
-      atoms[i].setHetero(true)
-    }
-
-    // Determine where to save results.
-    File saveDir = baseDir
-    File cif = new File(modelFilename)
-    String cifName = cif.getAbsolutePath()
-    if (saveDir == null || !saveDir.exists() || !saveDir.isDirectory() || !saveDir.canWrite()) {
-      saveDir = new File(FilenameUtils.getFullPath(cifName))
-    }
-    String dirName = saveDir.toString() + File.separator
-    String fileName = FilenameUtils.getName(cifName)
-
-    boolean savePDB = true
-    if (filenames.size() > 1) {
-      savePDB = false
-      // Open the XYZ file (with electrostatics turned off).
-      System.setProperty("mpoleterm", "false")
-      MolecularAssembly[] assemblies = potentialFunctions.openAll(filenames.get(1))
-      System.clearProperty("mpoleterm")
-
-      setActiveAssembly(assemblies[0])
-      Atom[] xyzAtoms = activeAssembly.getAtomArray()
-      int nXYZAtoms = xyzAtoms.length
-
-      // Used to determine if the CIF structure is missing hydrogen later on.
-      int numHydrogens = 0
-      for (Atom atom in xyzAtoms) {
-        if (atom.isHydrogen()) {
-          numHydrogens++
+        if (sgNum != -1) {
+          logger.info(format(" Command line International Tables Number: %d", sgNum))
+        } else {
+          logger.info(format(" Command line space group name: %s", sgName))
         }
       }
 
-      if (nAtoms == nXYZAtoms || (nAtoms + numHydrogens) == nXYZAtoms) {//TODO: Add >1 ASU
-        AtomContainer cifCDKAtoms = new AtomContainer()
-        AtomContainer xyzCDKAtoms = new AtomContainer()
-        for (int i = 0; i < nAtoms; i++) {
-          cifCDKAtoms.addAtom(new org.openscience.cdk.Atom(symbols[i],
-              new Point3d(atoms[i].getXYZ(null))))
-        }
-        AtomContainer nullCDKAtoms = new AtomContainer()
+      SpaceGroup sg
+      sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
+      if (sg == null) {
+        sg = SpaceGroupDefinitions.spaceGroupFactory(sgNum)
+      }
 
-        for (IAtom atom in cifCDKAtoms.atoms()) {
-          if (atom.toString() == null) {
-            nullCDKAtoms.addAtom(atom)
+      // Fall back to P1.
+      if (sg == null) {
+        logger.warning(" The space group could not be determined from the CIF file (using P1).")
+        sg = SpaceGroupDefinitions.spaceGroupFactory(1)
+      }
+
+      Cell cell = block.cell
+      double a = cell.lengthA.get(0)
+      double b = cell.lengthB.get(0)
+      double c = cell.lengthC.get(0)
+      double alpha = cell.angleAlpha.get(0)
+      double beta = cell.angleBeta.get(0)
+      double gamma = cell.angleGamma.get(0)
+
+      Crystal crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
+      logger.info(" New crystal:")
+      logger.info(crystal.toString())
+
+      AtomSite atomSite = block.atomSite
+      Column label = atomSite.label
+      Column typeSymbol = atomSite.typeSymbol
+      Column fractX = atomSite.fractX
+      Column fractY = atomSite.fractY
+      Column fractZ = atomSite.fractZ
+
+      int nAtoms = label.getRowCount()
+      logger.info(format("\n Number of atoms: %d", nAtoms))
+      Atom[] atoms = new Atom[nAtoms]
+
+      // Define per atom information for the PDB file.
+      String resName = "CIF"
+      int resID = 1
+      double occupancy = 1.0
+      double bfactor = 1.0
+      char altLoc = ' '
+      char chain = 'A'
+      String segID = "A"
+      String[] symbols = new String[nAtoms]
+
+      // Loop over atoms.
+      for (int i = 0; i < nAtoms; i++) {
+        symbols[i] = typeSymbol.get(i)
+        double x = fractX.get(i)
+        double y = fractY.get(i)
+        double z = fractZ.get(i)
+        double[] xyz = [x, y, z]
+        crystal.toCartesianCoordinates(xyz, xyz)
+        atoms[i] = new Atom(i + 1, label.get(i), altLoc, xyz, resName, resID, chain, occupancy,
+                bfactor, segID)
+        atoms[i].setHetero(true)
+      }
+
+      // Determine where to save results.
+      File saveDir = baseDir
+      File cif = new File(modelFilename)
+      String cifName = cif.getAbsolutePath()
+      if (saveDir == null || !saveDir.exists() || !saveDir.isDirectory() || !saveDir.canWrite()) {
+        saveDir = new File(FilenameUtils.getFullPath(cifName))
+      }
+      String dirName = saveDir.toString() + File.separator
+      String fileName = FilenameUtils.getName(cifName)
+
+      boolean savePDB = true
+      if (filenames.size() > 1) {
+        savePDB = false
+        // Open the XYZ file (with electrostatics turned off).
+        System.setProperty("mpoleterm", "false")
+        MolecularAssembly[] assemblies = potentialFunctions.openAll(filenames.get(1))
+        System.clearProperty("mpoleterm")
+
+        setActiveAssembly(assemblies[0])
+        Atom[] xyzAtoms = activeAssembly.getAtomArray()
+        int nXYZAtoms = xyzAtoms.length
+
+        // Used to determine if the CIF structure is missing hydrogen later on.
+        int numHydrogens = 0
+        for (Atom atom in xyzAtoms) {
+          if (atom.isHydrogen()) {
+            numHydrogens++
           }
         }
-        cifCDKAtoms.remove(nullCDKAtoms)
 
-        for (Atom atom : xyzAtoms) {
-          String atomName = getSymbol(atom.getAtomType().atomicNumber)
-          xyzCDKAtoms.addAtom(new org.openscience.cdk.Atom(atomName, new Point3d(atom.getXYZ(null))))
-        }
+        //TODO: Add >1 ASU
+        if (nAtoms == nXYZAtoms || (nAtoms + numHydrogens) == nXYZAtoms) {
+          AtomContainer cifCDKAtoms = new AtomContainer()
+          AtomContainer xyzCDKAtoms = new AtomContainer()
+          for (int i = 0; i < nAtoms; i++) {
+            cifCDKAtoms.addAtom(new org.openscience.cdk.Atom(symbols[i],
+                    new Point3d(atoms[i].getXYZ(null))))
+          }
+          AtomContainer nullCDKAtoms = new AtomContainer()
 
-        // Add known XYZ bonds; a limitation is that bonds all are given a Bond order of 1.
-        List<Bond> bonds = activeAssembly.getBondList()
-        Order order = Order.SINGLE
-        int xyzBonds = bonds.size()
-        for (Bond bond : bonds) {
-          xyzCDKAtoms.addBond(bond.getAtom(0).xyzIndex - 1, bond.getAtom(1).xyzIndex - 1, order)
-        }
+          for (IAtom atom in cifCDKAtoms.atoms()) {
+            if (atom.toString() == null) {
+              nullCDKAtoms.addAtom(atom)
+            }
+          }
+          cifCDKAtoms.remove(nullCDKAtoms)
 
-        // Assign CDK atom types for the XYZ molecule.
-        AtomTypeFactory factory = AtomTypeFactory.getInstance(
-            "org/openscience/cdk/config/data/jmol_atomtypes.txt",
-            xyzCDKAtoms.getBuilder())
+          for (Atom atom : xyzAtoms) {
+            String atomName = getSymbol(atom.getAtomType().atomicNumber)
+            xyzCDKAtoms.addAtom(new org.openscience.cdk.Atom(atomName, new Point3d(atom.getXYZ(null))))
+          }
 
-        for (IAtom atom : xyzCDKAtoms.atoms()) {
-          String atomTypeName = atom.getAtomTypeName()
-          if (atomTypeName == null || atomTypeName.length() == 0) {
-            IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
-            if (types.length > 0) {
-              IAtomType atomType = types[0]
-              atom.setAtomTypeName(atomType.getAtomTypeName())
+          // Add known XYZ bonds; a limitation is that bonds all are given a Bond order of 1.
+          List<Bond> bonds = activeAssembly.getBondList()
+          Order order = Order.SINGLE
+          int xyzBonds = bonds.size()
+          for (Bond bond : bonds) {
+            xyzCDKAtoms.addBond(bond.getAtom(0).xyzIndex - 1, bond.getAtom(1).xyzIndex - 1, order)
+          }
+
+          // Assign CDK atom types for the XYZ molecule.
+          AtomTypeFactory factory = AtomTypeFactory.getInstance(
+                  "org/openscience/cdk/config/data/jmol_atomtypes.txt",
+                  xyzCDKAtoms.getBuilder())
+
+          for (IAtom atom : xyzCDKAtoms.atoms()) {
+            String atomTypeName = atom.getAtomTypeName()
+            if (atomTypeName == null || atomTypeName.length() == 0) {
+              IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
+              if (types.length > 0) {
+                IAtomType atomType = types[0]
+                atom.setAtomTypeName(atomType.getAtomTypeName())
+              } else {
+                logger.info(" No atom type found for " + atom.toString())
+              }
+            }
+            factory.configure(atom)
+          }
+
+          // Compute bonds for CIF molecule.
+          factory = AtomTypeFactory.getInstance(
+                  "org/openscience/cdk/config/data/jmol_atomtypes.txt",
+                  cifCDKAtoms.getBuilder())
+
+          for (IAtom atom : cifCDKAtoms.atoms()) {
+            String atomTypeName = atom.getAtomTypeName()
+            if (atomTypeName == null || atomTypeName.length() == 0) {
+              IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
+              if (types.length > 0) {
+                IAtomType atomType = types[0]
+                atom.setAtomTypeName(atomType.getAtomTypeName())
+              } else {
+                logger.info(" No atom type found for " + atom.toString())
+              }
+            }
+            factory.configure(atom)
+          }
+
+          double maxCovalentRadius = 2.0
+          double minBondDistance = 0.5
+          double bondTolerance = 0.5
+          RebondTool rebonder = new RebondTool(maxCovalentRadius, minBondDistance, bondTolerance)
+          rebonder.rebond(cifCDKAtoms)
+
+          int cifBonds = cifCDKAtoms.bondCount
+
+          // Number of bonds matches.
+          if (cifBonds == xyzBonds) {
+            Pattern pattern =
+                    VentoFoggia.findIdentical(xyzCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
+            int[] p = pattern.match(cifCDKAtoms)
+            if (p != null && p.length == nAtoms) {
+              // Used matched atoms to update the positions of the XYZ file atoms.
+              for (int i = 0; i < p.length; i++) {
+                // logger.info(format(" %d XYZ %s -> CIF %s", i, xyzCDKAtoms.getAtom(i).getSymbol(), cifCDKAtoms.getAtom(p[i]).getSymbol()))
+                Point3d point3d = cifCDKAtoms.getAtom(p[i]).getPoint3d()
+                xyzAtoms[i].setXYZ(point3d.x, point3d.y, point3d.z)
+              }
             } else {
-              logger.info(" No atom type found for " + atom.toString())
-            }
-          }
-          factory.configure(atom)
-        }
-
-        // Compute bonds for CIF molecule.
-        factory = AtomTypeFactory.getInstance(
-            "org/openscience/cdk/config/data/jmol_atomtypes.txt",
-            cifCDKAtoms.getBuilder())
-
-        for (IAtom atom : cifCDKAtoms.atoms()) {
-          String atomTypeName = atom.getAtomTypeName()
-          if (atomTypeName == null || atomTypeName.length() == 0) {
-            IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
-            if (types.length > 0) {
-              IAtomType atomType = types[0]
-              atom.setAtomTypeName(atomType.getAtomTypeName())
-            } else {
-              logger.info(" No atom type found for " + atom.toString())
-            }
-          }
-          factory.configure(atom)
-        }
-
-        double maxCovalentRadius = 2.0
-        double minBondDistance = 0.5
-        double bondTolerance = 0.5
-        RebondTool rebonder = new RebondTool(maxCovalentRadius, minBondDistance, bondTolerance)
-        rebonder.rebond(cifCDKAtoms)
-
-        int cifBonds = cifCDKAtoms.bondCount
-
-        // Number of bonds matches.
-        if (cifBonds == xyzBonds) {
-          Pattern pattern =
-              VentoFoggia.findIdentical(xyzCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
-          int[] p = pattern.match(cifCDKAtoms)
-          if (p != null && p.length == nAtoms) {
-            // Used matched atoms to update the positions of the XYZ file atoms.
-            for (int i = 0; i < p.length; i++) {
-              // logger.info(format(" %d XYZ %s -> CIF %s", i, xyzCDKAtoms.getAtom(i).getSymbol(), cifCDKAtoms.getAtom(p[i]).getSymbol()))
-              Point3d point3d = cifCDKAtoms.getAtom(p[i]).getPoint3d()
-              xyzAtoms[i].setXYZ(point3d.x, point3d.y, point3d.z)
+              logger.info(" CIF and XYZ files don't match.")
+              savePDB = true
             }
 
-
-          } else {
-            logger.info(" CIF and XYZ files don't match.")
-            savePDB = true
-          }
-
-        } else if ((cifBonds + numHydrogens) % xyzBonds == 0) {
-          // Hydrogens most likely missing from file.
-          logger.info(" CIF may contain implicit hydrogen -- attempting to patch.")
-          // Match heavy atoms between CIF and XYZ
-          Pattern pattern = VentoFoggia.
-              findSubstructure(cifCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
-          int[] p = pattern.match(xyzCDKAtoms)
-          if (p != null && p.length == nAtoms) {
-            // Used matched atoms to update the positions of the XYZ file atoms.
-            for (int i = 0; i < p.length; i++) {
-              Point3d point3d = cifCDKAtoms.getAtom(i).getPoint3d()
-              xyzAtoms[p[i]].setXYZ(point3d.x, point3d.y, point3d.z)
-            }
-            // Add in hydrogen atoms
-            for (Atom hydrogen in xyzAtoms) {
-              if (hydrogen.isHydrogen()) {
-                Bond bond0 = hydrogen.getBonds()[0]
-                Atom atom1 = bond0.get1_2(hydrogen)
-                double angle0_2 = 0
-                List<Angle> anglesList = hydrogen.getAngles() // Same as bond
-                Atom atom1_2 = null
-                switch (anglesList.size()) {
-                  case 0:
-                    // H-Cl No angles
-                    logger.info("Structure may contain only two atoms. Not supported yet.")
-                    break
-                  case 1:
-                    // H-O=C Need torsion
-                    for (Angle angle in anglesList) {
-                      atom1_2 = angle.get1_3(hydrogen)
-                      if (atom1_2 != null && !atom1_2.isHydrogen()) {
-                        angle0_2 = angle.angleType.angle[0]
-                      }
-                      if (angle0_2 != 0) {
-                        //if angle1_3 is found then no need to look for another atom.
-                        break
-                      }
-                    }
-                    Atom atom2_3
-                    List<Bond> bonds2 = atom1_2.getBonds()
-                    if (atom1 == bonds2[0].get1_2(atom1_2)) { // Ensure first bond doesnt go to atom2
-                      atom2_3 = bonds2[1].get1_2(atom1_2)
-                    } else { //Else get first bond and assign atom to atom3
-                      atom2_3 = bonds2[0].get1_2(atom1_2)
-                    }
-                    double diAng =
-                        dihedralAngle(hydrogen.getXYZ(null), atom1.getXYZ(null),
-                            atom1_2.getXYZ(null), atom2_3.getXYZ(null))
-                    intxyz(hydrogen, atom1, bond0.bondType.distance, atom1_2, angle0_2, atom2_3,
-                        Math.toDegrees(diAng), 0)
-                    break
-                  default:
-                    // H-C-C
-                    Atom atom1_2B = null
-                    double angle0_3 = 0
-                    Atom proposedAtom
-                    double proposedAngle = 0
-                    for (Angle angle in anglesList) {
-                      proposedAtom = angle.get1_3(hydrogen)
-                      if (proposedAtom != null && !proposedAtom.isHydrogen()) {
-                        proposedAngle = angle.angleType.angle[0]
-                      }
-                      if (proposedAngle != 0) {
-                        // If angle1_3 is found then no need to look for another atom.
-                        if (angle0_2 != 0) {
-                          atom1_2 = proposedAtom
-                          angle0_3 = proposedAngle
-                        } else {
-                          atom1_2B = proposedAtom
-                          angle0_2 = proposedAngle
+          } else if ((cifBonds + numHydrogens) % xyzBonds == 0) {
+            // Hydrogens most likely missing from file.
+            logger.info(" CIF may contain implicit hydrogen -- attempting to patch.")
+            // Match heavy atoms between CIF and XYZ
+            Pattern pattern = VentoFoggia.
+                    findSubstructure(cifCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
+            int[] p = pattern.match(xyzCDKAtoms)
+            if (p != null && p.length == nAtoms) {
+              // Used matched atoms to update the positions of the XYZ file atoms.
+              for (int i = 0; i < p.length; i++) {
+                Point3d point3d = cifCDKAtoms.getAtom(i).getPoint3d()
+                xyzAtoms[p[i]].setXYZ(point3d.x, point3d.y, point3d.z)
+              }
+              // Add in hydrogen atoms
+              Atom lastKnownAtom1 = null
+              int knownCount = 0
+              for (Atom hydrogen in xyzAtoms) {
+                if (hydrogen.isHydrogen()) {
+                  Bond bond0 = hydrogen.getBonds()[0]
+                  Atom atom1 = bond0.get1_2(hydrogen)
+                  double angle0_2 = 0
+                  List<Angle> anglesList = hydrogen.getAngles() // Same as bond
+                  Atom atom2 = null
+                  switch (anglesList.size()) {
+                    case 0:
+                      // H-Cl No angles
+                      logger.info("Structure may contain only two atoms. Not supported yet.")
+                      break
+                    case 1:
+                      // H-O=C Need torsion
+                      for (Angle angle in anglesList) {
+                        atom2 = angle.get1_3(hydrogen)
+                        if (atom2 != null && !atom2.isHydrogen()) {
+                          angle0_2 = angle.angleType.angle[0]
                         }
-                        if (angle0_2 != 0 && angle0_3 != 0) {
+                        if (angle0_2 != 0) {
+                          //if angle0_2 is found then no need to look for another atom.
                           break
                         }
                       }
-                    }
-                    intxyz(hydrogen, atom1, bond0.bondType.distance, atom1_2, angle0_2, atom1_2B, angle0_3, 1)
+                      List<Bond> bonds2 = atom2.getBonds()
+                      Atom atom3 = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
+                      double diAng =
+                              dihedralAngle(hydrogen.getXYZ(null), atom1.getXYZ(null),
+                                      atom2.getXYZ(null), atom3.getXYZ(null))
+                      intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom3,
+                              Math.toDegrees(diAng), 0)
+                      break
+                    default:
+                      // H-C(-C)(-C)-C
+                      Atom atom2B = null
+                      double angle0_2B = 0
+                      Atom proposedAtom
+                      double proposedAngle = 0
+                      int chiral = 1
+                      for (Angle angle in anglesList) {
+                        proposedAtom = angle.get1_3(hydrogen)
+                          if (proposedAtom != null && !proposedAtom.isHydrogen()) {
+                            proposedAngle = angle.angleType.angle[0]
+                          }
+                          if (proposedAngle != 0) {
+                            // If angle1_3 is found then no need to look for another atom.
+                            if (angle0_2 != 0) {
+                              atom2B = proposedAtom
+                              angle0_2B = proposedAngle
+                            } else {
+                              atom2 = proposedAtom
+                              angle0_2 = proposedAngle
+                            }
+                            proposedAngle = 0.0
+                          }
+                        if (angle0_2 != 0 && angle0_2B != 0) {
+                          break
+                        }
+                      }
+                      if (lastKnownAtom1 == null || lastKnownAtom1 != atom1) {
+                        lastKnownAtom1 = atom1
+                        knownCount = 0
+                      } else {
+                        knownCount++
+                      }
+                      if (angle0_2B == 0.0) {
+                        // Hydrogen position depends on other hydrogens, use generic location
+                        chiral = 0
+                        List<Bond> bonds2 = atom2.getBonds()
+                        atom2B = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
+                        // Evenly space out hydrogens
+                        angle0_2B = 180.0 - 120.0 * knownCount
+                      } else if (anglesList.size() == 2) {
+                        // Trigonal hydrogen use equipartition between selected atoms
+                        chiral = 3
+                      } else if (knownCount == 1) {
+                        // Already created one hydrogen (chiral = 1), use other.
+                        chiral = -1
+                      }
+                      //TODO decern whether to use chiral = 1 or -1 when angles are to three heavy atoms.
+                      intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom2B, angle0_2B, chiral)
+                  }
                 }
               }
+            } else {
+              logger.info(" Could not match heavy atoms between CIF and XYZ.")
+              savePDB = true
             }
           } else {
-            logger.info(" Could not match heavy atoms between CIF and XYZ.")
+            logger.info(format(" CIF (%d) and XYZ (%d) have a different number of bonds.", cifBonds,
+                    xyzBonds))
             savePDB = true
           }
         } else {
-          logger.info(format(" CIF (%d) and XYZ (%d) have a different number of bonds.", cifBonds,
-              xyzBonds))
+          logger.info(format(" CIF (%d) and XYZ (%d) files have different numbers of atoms.", nAtoms,
+                  nXYZAtoms))
           savePDB = true
         }
-      } else {
-        logger.info(format(" CIF (%d) and XYZ (%d) files have different numbers of atoms.", nAtoms,
-            nXYZAtoms))
-        savePDB = true
       }
-    }
 
-    if (savePDB) {
-      // Save a PDB file if there is no XYZ file supplied.
-      fileName = FilenameUtils.removeExtension(fileName) + ".pdb"
-      File modelFile = new File(dirName + fileName)
-      File saveFile = potentialFunctions.versionFile(modelFile)
+      setVersioning(PREFIX)
+      if (savePDB) {
+        // Save a PDB file if there is no XYZ file supplied.
+        fileName = FilenameUtils.removeExtension(fileName) + ".pdb"
+        File saveFile = version(new File(dirName + fileName))
 
-      // Write out PDB file.
-      FileWriter fw = new FileWriter(saveFile, false)
-      BufferedWriter bw = new BufferedWriter(fw)
-      bw.write(crystal.toCRYST1())
-      for (int i = 0; i < nAtoms; i++) {
-        bw.write(toPDBAtomLine(atoms[i]))
-      }
-      bw.write("END\n")
-      bw.close()
-      logger.info("\n Saved PDB file to " + saveFile.getAbsolutePath())
-    } else {
-      // Update the active molecular assembly to use the CIF space group and unit cell.
-      activeAssembly.getPotentialEnergy().setCrystal(crystal)
-      // Choose a location to save the file.
-      fileName = FilenameUtils.removeExtension(fileName) + ".xyz"
-      File modelFile = new File(dirName + fileName)
-      File saveFile = potentialFunctions.versionFile(modelFile)
-
-      // Write out the result.
-      potentialFunctions.saveAsXYZ(activeAssembly, saveFile)
-      logger.info("\n Saved XYZ file:        " + saveFile.getAbsolutePath())
-
-      // Write out a property file.
-      fileName = FilenameUtils.removeExtension(fileName) + ".properties"
-      File propertyFile = new File(dirName + fileName)
-      if (!propertyFile.exists()) {
-        FileWriter fw = new FileWriter(propertyFile, false)
+        // Write out PDB file.
+        FileWriter fw = new FileWriter(saveFile, false)
         BufferedWriter bw = new BufferedWriter(fw)
-        ForceField forceField = activeAssembly.getForceField()
-        String parameters = forceField.getString("parameters", "none")
-        if (parameters != null && !parameters.equalsIgnoreCase("none")) {
-          bw.write(format("parameters %s\n", parameters))
+        bw.write(crystal.toCRYST1())
+        for (int i = 0; i < nAtoms; i++) {
+          bw.write(toPDBAtomLine(atoms[i]))
         }
-        String patch = forceField.getString("patch", "none")
-        if (patch != null && !patch.equalsIgnoreCase("none")) {
-          bw.write(format("patch %s\n", patch))
-        }
-        bw.write(format("spacegroup %s\n", crystal.spaceGroup.shortName))
-
+        bw.write("END\n")
         bw.close()
-        logger.info("\n Saved properties file: " + propertyFile.getAbsolutePath())
+        logger.info("\n Saved PDB file to " + saveFile.getAbsolutePath())
       } else {
-        logger.info("\n Property file already exists:  " + propertyFile.getAbsolutePath())
+        // Update the active molecular assembly to use the CIF space group and unit cell.
+        activeAssembly.getPotentialEnergy().setCrystal(crystal)
+        // Choose a location to save the file.
+        fileName = FilenameUtils.removeExtension(fileName) + ".xyz"
+        File saveFile = version(new File(dirName + fileName))
+
+        // Write out the result.
+        potentialFunctions.saveAsXYZ(activeAssembly, saveFile)
+        logger.info("\n Saved XYZ file:        " + saveFile.getAbsolutePath())
+
+        // Write out a property file.
+        fileName = FilenameUtils.removeExtension(fileName) + ".properties"
+        File propertyFile = version(new File(dirName + fileName))
+        if (!propertyFile.exists()) {
+          FileWriter fw = new FileWriter(propertyFile, false)
+          BufferedWriter bw = new BufferedWriter(fw)
+          ForceField forceField = activeAssembly.getForceField()
+          String parameters = forceField.getString("parameters", "none")
+          if (parameters != null && !parameters.equalsIgnoreCase("none")) {
+            bw.write(format("parameters %s\n", parameters))
+          }
+          String patch = forceField.getString("patch", "none")
+          if (patch != null && !patch.equalsIgnoreCase("none")) {
+            bw.write(format("patch %s\n", patch))
+          }
+          bw.write(format("spacegroup %s\n", crystal.spaceGroup.shortName))
+
+          bw.close()
+          logger.info("\n Saved properties file: " + propertyFile.getAbsolutePath())
+        } else {
+          logger.info("\n Property file already exists:  " + propertyFile.getAbsolutePath())
+        }
       }
     }
 

--- a/modules/potential/src/main/java/ffx/potential/parsers/SystemFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/SystemFilter.java
@@ -268,7 +268,7 @@ public abstract class SystemFilter {
       if (vers == Versioning.PREFIX_ABSOLUTE || vers == Versioning.POSTFIX_ABSOLUTE) {
         return versionAbsolute(file, (vers == Versioning.PREFIX_ABSOLUTE));
       } else {
-        return version(file, (vers == Versioning.PREFIX_ABSOLUTE));
+        return version(file, (vers == Versioning.PREFIX));
       }
     }
   }


### PR DESCRIPTION
SuperposeCrystals: Refactored so most of the standard functionality is held in ProgressiveAlignmentOfCrystals. This should facilitate its use for people not familiar with the code. Updated comments and flag descriptions to be more clear.

ProgressiveAlignmentOfCrystals: Added functionality from SuperposeCrystals. Replaced inner loop molecule switching (numSearch/numSearch2) with a more thorough conformer checking procedure. Inflated spheres are searched to determine number of conformations prior to performing alignments.

ProgressiveAlignmentOfCrystalsTest: Slight tweak to asserted value associated with Z'>1 (previous algorithm treated Z'>1 as a whole rather than independently).

Crystal: Constructor now attempts to convert between hexagonal and rhombohedral space groups when the lattice parameters do not satisfy the provided lattice system. It is disturbingly common to have rhombohedral lattice parameters provided to a hexagonal space group or visa versa.

SpaceGroupConversions: Contains functionality for correcting cases where lattice parameters are correct, but space group is mislabeled.

CIFtoXYZ: Loops over concatenated CIF files and produces individual XYZ files (space groups may differ between concatenated CIFs). Additionally, improved the automatic addition of hydrogens to CIF files. Previously when more than one hydrogen was added to an atom they would overlap.

SystemFilter: Fixed typo that prevented non-absolute versioning (_e.g._ mol.xyz, mol_0.xyz, mol_1.xyz, _etc._).