### PR TITLE
Improvements to the handling of crystal structures and crystal structure comparisons.

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -117,6 +117,13 @@ class SuperposeCrystals extends AlgorithmsScript {
   int zPrime2
 
   /**
+   * --sc or --symCheck Avoid ambiguous symmetry regions.
+   */
+  @Option(names = ['--sc', '--symCheck'], paramLabel = "false", defaultValue = "false",
+          description = 'Ignore atoms with the same bonded environment.')
+  private static boolean symCheck
+
+  /**
    * -w or --write Write out the RMSD matrix.
    */
   @Option(names = ['-w', '--write'], paramLabel = "false", defaultValue = "false",
@@ -256,7 +263,7 @@ class SuperposeCrystals extends AlgorithmsScript {
     }
 
     runningStatistics = pac.comparisons(numAU, numInflatedAU, numSearch, numSearch2, zPrime, zPrime2, alphaCarbons,
-        noHydrogen, exhaustive, savePDB, restart, write, ares, pacFilename)
+        noHydrogen, symCheck, exhaustive, savePDB, restart, write, ares, pacFilename)
 
     return this
   }

--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -117,11 +117,11 @@ class SuperposeCrystals extends AlgorithmsScript {
   int zPrime2
 
   /**
-   * --sc or --symCheck Avoid ambiguous symmetry regions.
+   * --re or --removeEquivalent Remove atoms with equivalent bonded environments.
    */
-  @Option(names = ['--sc', '--symCheck'], paramLabel = "false", defaultValue = "false",
-          description = 'Ignore atoms with the same bonded environment.')
-  private static boolean symCheck
+  @Option(names = ['--re', '--removeEquivalent'], paramLabel = "false", defaultValue = "false",
+          description = 'Ignore atoms with similar bonded environment .')
+  private static boolean renameEq
 
   /**
    * -w or --write Write out the RMSD matrix.
@@ -166,11 +166,18 @@ class SuperposeCrystals extends AlgorithmsScript {
   private static boolean noHydrogen
 
   /**
-   * --sa or --saveAres Save out PDB in ARES input format.
+   * --sm or --saveMachineLearning Save out PDB and CSV for machine learning.
    */
-  @Option(names = ['--sa', '--saveAres'], paramLabel = "false", defaultValue = "false",
-          description = 'Final structures for each comparison will be written out in ARES input format.')
-  private static boolean ares
+  @Option(names = ['--sm', '--saveMachineLearning'], paramLabel = "false", defaultValue = "false",
+          description = 'Final structures for each comparison will be written out with RMSD in a CSV.')
+  private static boolean machineLearning
+
+  /**
+   * --mw or --massWeighted Weight atomic masses for comparison.
+   */
+  @Option(names = ['--mw', '--massWeighted'], paramLabel = "false", defaultValue = "false",
+          description = 'Weight atomic masses for the comparison.')
+  private static boolean massWeighted
 
   /**
    * The final argument(s) should be two or more filenames (same file twice if comparing same structures).
@@ -259,12 +266,12 @@ class SuperposeCrystals extends AlgorithmsScript {
     String pacFilename = concat(getFullPath(filename), getBaseName(filename) + ".txt")
 
     // To save in ARES format a PDB must be written out.
-    if(ares){
+    if(machineLearning){
       savePDB = true
     }
 
     runningStatistics = pac.comparisons(numAU, numInflatedAU, numSearch, numSearch2, zPrime, zPrime2, alphaCarbons,
-        noHydrogen, symCheck, exhaustive, savePDB, restart, write, ares, pacFilename)
+        noHydrogen, massWeighted, renameEq, exhaustive, savePDB, restart, write, machineLearning, pacFilename)
 
     return this
   }

--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -249,6 +249,7 @@ class SuperposeCrystals extends AlgorithmsScript {
       algorithmFunctions.openAll(filenames.get(1))
       targetFilter = algorithmFunctions.getFilter()
     }
+    atomSelectionOptions.setActiveAtoms(targetFilter.getActiveMolecularSystem())
 
     // Compare structures in baseFilter and targetFilter.
     ProgressiveAlignmentOfCrystals pac = new ProgressiveAlignmentOfCrystals(baseFilter, targetFilter, isSymmetric)

--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/ProgressiveAlignmentTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/ProgressiveAlignmentTest.java
@@ -70,7 +70,7 @@ public class ProgressiveAlignmentTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.0851007, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.11101375, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the CrystalSuperpose script without hydrogens. */
@@ -89,7 +89,7 @@ public class ProgressiveAlignmentTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.0810508, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.0825499, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the CrystalSuperpose script in Sohncke group. */
@@ -142,7 +142,7 @@ public class ProgressiveAlignmentTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.15354157, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.1509703, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   @Test

--- a/modules/crystal/src/main/java/ffx/crystal/Crystal.java
+++ b/modules/crystal/src/main/java/ffx/crystal/Crystal.java
@@ -254,7 +254,7 @@ public class Crystal {
         this.alpha = alpha;
         this.beta = beta;
         this.gamma = gamma;
-        spaceGroup = SpaceGroupDefinitions.spaceGroupFactory(sg);
+        spaceGroup = tempSG;
         crystalSystem = spaceGroup.crystalSystem;
         latticeSystem = spaceGroup.latticeSystem;
         logger.severe(sb.toString());
@@ -267,7 +267,7 @@ public class Crystal {
       this.alpha = alpha;
       this.beta = beta;
       this.gamma = gamma;
-      spaceGroup = SpaceGroupDefinitions.spaceGroupFactory(sg);
+      spaceGroup = tempSG;
       crystalSystem = spaceGroup.crystalSystem;
       latticeSystem = spaceGroup.latticeSystem;
     }

--- a/modules/crystal/src/main/java/ffx/crystal/LatticeSystem.java
+++ b/modules/crystal/src/main/java/ffx/crystal/LatticeSystem.java
@@ -91,6 +91,8 @@ public enum LatticeSystem {
     double beta = 60.0 + random() * 60.0;
     double gamma = 60.0 + random() * 60.0;
     double[] params = {0.1 + random(), 0.1 + random(), 0.1 + random(), alpha, beta, gamma};
+    double ab = 0.5 * (params[0] + params[1]);
+    double abc = (params[0] + params[1] + params[2]) / 3.0;
     switch (this) {
       case TRICLINIC_LATTICE:
         break;
@@ -107,7 +109,6 @@ public enum LatticeSystem {
         break;
       case TETRAGONAL_LATTICE:
         // a = b, alpha = beta = gamma = 90
-        double ab = 0.5 * (params[0] + params[1]);
         params[0] = ab;
         params[1] = ab;
         params[3] = 90.0;
@@ -116,7 +117,6 @@ public enum LatticeSystem {
         break;
       case RHOMBOHEDRAL_LATTICE:
         // a = b = c, alpha = beta = gamma.
-        double abc = (params[0] + params[1] + params[2]) / 3.0;
         double angles = (params[3] + params[4] + params[5]) / 3.0;
         params[0] = abc;
         params[1] = abc;
@@ -127,7 +127,6 @@ public enum LatticeSystem {
         break;
       case HEXAGONAL_LATTICE:
         // a = b, alpha = beta = 90, gamma = 120
-        ab = 0.5 * (params[0] + params[1]);
         params[0] = ab;
         params[1] = ab;
         params[3] = 90.0;
@@ -137,7 +136,6 @@ public enum LatticeSystem {
       case CUBIC_LATTICE:
       default:
         // a = b = c, alpha = beta = gamma = 90
-        abc = (params[0] + params[1] + params[2]) / 3.0;
         params[0] = abc;
         params[1] = abc;
         params[2] = abc;
@@ -192,19 +190,21 @@ public enum LatticeSystem {
   }
 
   /**
-   * Check that the lattice parameters satisfy the restrictions of the lattice systems.
+   * Change the lattice parameters to satisfy the restrictions of the lattice system.
    *
-   * @param a the a-axis length.
-   * @param b the b-axis length.
-   * @param c the c-axis length.
-   * @param alpha the alpha angle.
-   * @param beta the beta angle.
-   * @param gamma the gamma angle.
-   * @return True if the restrictions are satisfied, false otherwise.
+   * @param a the proposed a-axis length.
+   * @param b the proposed b-axis length.
+   * @param c the proposed c-axis length.
+   * @param alpha the proposed alpha angle.
+   * @param beta the proposed beta angle.
+   * @param gamma the proposed gamma angle.
+   * @return Adjusted parameters if the restrictions are satisfied, original parameters otherwise.
    */
   public double[] fixParameters(double a, double b, double c, double alpha, double beta,
                                  double gamma) {
     double[] parameters = {a,b,c,alpha,beta,gamma};
+    double ab = (parameters[0] + parameters[1])/2;
+    double abc = (parameters[0] + parameters[1] + parameters[2])/3;
     switch (this) {
       case TRICLINIC_LATTICE:
         // No restrictions.
@@ -222,7 +222,6 @@ public enum LatticeSystem {
         return parameters;
       case TETRAGONAL_LATTICE:
         // a = b, alpha = beta = gamma = 90
-        double ab = (parameters[0] + parameters[1])/2;
         parameters[0] = ab;
         parameters[1] = ab;
         parameters[3] = 90.0;
@@ -231,7 +230,6 @@ public enum LatticeSystem {
         return parameters;
       case RHOMBOHEDRAL_LATTICE:
         // a = b = c, alpha = beta = gamma.
-        double abc = (parameters[0] + parameters[1] + parameters[2])/3;
         double angles = (parameters[3] + parameters[4] + parameters[5])/3;
         parameters[0] = abc;
         parameters[1] = abc;
@@ -242,7 +240,6 @@ public enum LatticeSystem {
         return parameters;
         case HEXAGONAL_LATTICE:
         // a = b, alpha = beta = 90, gamma = 120
-          ab = (parameters[0] + parameters[1])/2;
           parameters[0] = ab;
           parameters[1] = ab;
           parameters[3] = 90.0;
@@ -251,7 +248,6 @@ public enum LatticeSystem {
           return parameters;
       case CUBIC_LATTICE:
         // a = b = c; alpha = beta = gamma = 90
-        abc = (parameters[0] + parameters[1] + parameters[2])/3;
         parameters[0] = abc;
         parameters[1] = abc;
         parameters[2] = abc;
@@ -268,6 +264,7 @@ public enum LatticeSystem {
   /**
    * Returns the default b-axis for the lattice system.
    *
+   * @param aaxis the a-axis length is the best guess for b-axis.
    * @return default b-axis value
    */
   public double getDefaultBAxis(double aaxis) {

--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroup.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroup.java
@@ -37,7 +37,7 @@
 // ******************************************************************************
 package ffx.crystal;
 
-import static ffx.crystal.SpaceGroupInfo.sohnckeGroup;
+import static ffx.crystal.SpaceGroupInfo.isSohnckeGroup;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -127,7 +127,7 @@ public class SpaceGroup {
     this.asuLimitOperators = asuLimitOperators;
     this.asuLimits = asuLimits;
     this.pdbName = pdbName;
-    this.respectsChirality = sohnckeGroup(number);
+    this.respectsChirality = isSohnckeGroup(number);
     this.symOps = new ArrayList<>(Arrays.asList(symOps));
 
     // ToDo: Crystal systems are subdivided into crystal classes. This info needs to be added to

--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
@@ -7877,7 +7877,8 @@ public class SpaceGroupDefinitions {
    */
   static SpaceGroup getAlternativeSpaceGroup(String name) {
     SpaceGroup spaceGroup = null;
-    if (name.equalsIgnoreCase("P21/a") || name.equalsIgnoreCase("P 1 21/a 1")) {
+    name = name.replaceAll(" +", "");
+    if (name.equalsIgnoreCase("P21/a") || name.equalsIgnoreCase("P121/a1")) {
       spaceGroup =
           new SpaceGroup(
               14,
@@ -7895,7 +7896,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_mX_mY_Z, SymOp.Tr_12_0_12),
               new SymOp(SymOp.Rot_mX_mY_mZ, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_X_Y_mZ, SymOp.Tr_12_0_12));
-    } else if (name.equalsIgnoreCase("P21/n") || name.equalsIgnoreCase("P 1 21/n 1")) {
+    } else if (name.equalsIgnoreCase("P21/n") || name.equalsIgnoreCase("P121/n1")) {
       spaceGroup =
               new SpaceGroup(
                       14,
@@ -7913,6 +7914,24 @@ public class SpaceGroupDefinitions {
                       new SymOp(SymOp.Rot_mX_Y_mZ, SymOp.Tr_12_12_12),
                       new SymOp(SymOp.Rot_mX_mY_mZ, SymOp.Tr_0_0_0),
                       new SymOp(SymOp.Rot_X_mY_Z, SymOp.Tr_12_12_12));
+    } else if (name.equalsIgnoreCase("P21212A") || name.equalsIgnoreCase("P 21 21 2 A")) {
+      spaceGroup =
+              new SpaceGroup(
+                      18,
+                      4,
+                      4,
+                      "P21212A",
+                      "PG222",
+                      "P 21 21 2 A",
+                      ORTHORHOMBIC,
+                      ORTHORHOMBIC_LATTICE,
+                      L222,
+                      new ASULimit[] {ASULimit.LT, ASULimit.LTE, ASULimit.LT},
+                      new double[] {1.0, f14, 1.0},
+                      new SymOp(SymOp.Rot_X_Y_Z, SymOp.Tr_0_0_0),
+                      new SymOp(SymOp.Rot_mX_mY_Z, SymOp.Tr_12_12_0),
+                      new SymOp(SymOp.Rot_mX_Y_mZ, SymOp.Tr_0_12_0),
+                      new SymOp(SymOp.Rot_X_mY_mZ, SymOp.Tr_12_0_0));
     } else if (name.equalsIgnoreCase("R3") || name.equalsIgnoreCase("R 3")) {
       spaceGroup =
           new SpaceGroup(
@@ -8010,7 +8029,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_Y_X_Z, SymOp.Tr_12_12_12),
               new SymOp(SymOp.Rot_Z_Y_X, SymOp.Tr_12_12_12),
               new SymOp(SymOp.Rot_X_Z_Y, SymOp.Tr_12_12_12));
-    } else if (name.equalsIgnoreCase("R-3m")  || name.equalsIgnoreCase("R -3 2/m")) {
+    } else if (name.equalsIgnoreCase("R-3m")  || name.equalsIgnoreCase("R-32/m")) {
       spaceGroup =
           new SpaceGroup(
               166,
@@ -8036,7 +8055,7 @@ public class SpaceGroupDefinitions {
               new SymOp(SymOp.Rot_Y_X_Z, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_Z_Y_X, SymOp.Tr_0_0_0),
               new SymOp(SymOp.Rot_X_Z_Y, SymOp.Tr_0_0_0));
-    } else if (name.equalsIgnoreCase("R-3c") || name.equalsIgnoreCase("R -3 2/c")) {
+    } else if (name.equalsIgnoreCase("R-3c") || name.equalsIgnoreCase("R-32/c")) {
       spaceGroup =
           new SpaceGroup(
               167,
@@ -8100,9 +8119,12 @@ public class SpaceGroupDefinitions {
    * @since 1.0
    */
   public static SpaceGroup spaceGroupFactory(String name) {
-    SpaceGroup spaceGroup = spaceGroupFactory(spaceGroupNumber(name));
+    String n = name.trim();
+    // Many CIF files have extraneous parenthesis not found in PDB or FFX SG formats (e.g. "P2(1)/c").
+    n = n.replaceAll("[()]", "");
+    SpaceGroup spaceGroup = spaceGroupFactory(spaceGroupNumber(n));
     if (spaceGroup == null) {
-      spaceGroup = getAlternativeSpaceGroup(name);
+      spaceGroup = getAlternativeSpaceGroup(n);
     }
     return spaceGroup;
   }
@@ -8119,8 +8141,6 @@ public class SpaceGroupDefinitions {
       return -1;
     }
     String n = name.trim();
-    // Many CIF files have extraneous parenthesis not found in PDB or FFX SG formats (e.g. "P2(1)/c").
-    n = n.replaceAll("[()]", "");
     int num = SpaceGroupInfo.spaceGroupNames.length;
     for (int i = 0; i < num; i++) {
       String s1 = SpaceGroupInfo.spaceGroupNames[i];

--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroupInfo.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroupInfo.java
@@ -309,7 +309,7 @@ public class SpaceGroupInfo {
    * @param number Space group number.
    * @return true if the space group is a Sohncke Group.
    */
-  public static boolean sohnckeGroup(int number) {
+  public static boolean isSohnckeGroup(int number) {
     if (number == 1) {
       return true;
     } else if (isBetween(number, 3, 5)) {
@@ -330,10 +330,8 @@ public class SpaceGroupInfo {
       return true;
     } else if (isBetween(number, 195, 199)) {
       return true;
-    } else if (isBetween(number, 207, 214)) {
-      return true;
+    } else {
+      return isBetween(number, 207, 214);
     }
-
-    return false;
   }
 }

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
@@ -38,6 +38,7 @@
 package ffx.potential.groovy
 
 import ffx.crystal.Crystal
+import ffx.crystal.LatticeSystem
 import ffx.crystal.SpaceGroup
 import ffx.crystal.SpaceGroupDefinitions
 import ffx.numerics.Potential
@@ -45,8 +46,11 @@ import ffx.potential.MolecularAssembly
 import ffx.potential.bonded.Angle
 import ffx.potential.bonded.Atom
 import ffx.potential.bonded.Bond
+import ffx.potential.bonded.Molecule
 import ffx.potential.cli.PotentialScript
 import ffx.potential.parameters.ForceField
+import ffx.potential.parsers.XYZFilter
+import ffx.potential.parsers.PDBFilter
 
 import org.apache.commons.io.FilenameUtils
 import org.openscience.cdk.AtomContainer
@@ -62,7 +66,12 @@ import org.openscience.cdk.isomorphism.VentoFoggia
 import org.rcsb.cif.CifIO
 import org.rcsb.cif.model.Column
 import org.rcsb.cif.schema.StandardSchemata
-import org.rcsb.cif.schema.core.*
+import org.rcsb.cif.schema.core.AtomSite
+import org.rcsb.cif.schema.core.Chemical
+import org.rcsb.cif.schema.core.CifCoreBlock
+import org.rcsb.cif.schema.core.CifCoreFile
+import org.rcsb.cif.schema.core.Cell
+import org.rcsb.cif.schema.core.Symmetry
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
@@ -72,13 +81,11 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import static ffx.numerics.math.DoubleMath.dihedralAngle
+import static ffx.numerics.math.DoubleMath.dist
 import static ffx.potential.bonded.BondedUtils.intxyz
-import static ffx.potential.parsers.PDBFilter.toPDBAtomLine
-import static ffx.potential.parsers.SystemFilter.setVersioning
-import static ffx.potential.parsers.SystemFilter.Versioning.PREFIX
-import static ffx.potential.parsers.SystemFilter.version
 import static java.lang.String.format
 import static org.openscience.cdk.tools.periodictable.PeriodicTable.getSymbol
+import static org.openscience.cdk.tools.periodictable.PeriodicTable.getCovalentRadius
 
 /**
  * The CIFtoXYZ script converts a CIF file to an XYZ file including atom types.
@@ -86,467 +93,688 @@ import static org.openscience.cdk.tools.periodictable.PeriodicTable.getSymbol
  * <br>
  * Usage:
  * <br>
- * ffxc test.CIFtoXYZ &lt;filename.cif&gt; &lt;filename.pdb&gt;
+ * ffxc CIFtoXYZ &lt;filename.cif&gt; &lt;filename.pdb&gt;
  */
-@Command(description = " Convert a single molecule CIF file to XYZ format.", name = "ffxc test.CIFtoXYZ")
+@Command(description = " Convert a single molecule CIF file to XYZ format.", name = "ffxc CIFtoXYZ")
 class CIFtoXYZ extends PotentialScript {
 
-  /**
-   * --sg or --spaceGroupNumber Override the CIF space group.
-   */
-  @Option(names = ['--sg', '--spaceGroupNumber'], paramLabel = "-1", defaultValue = "-1",
-      description = 'Override the CIF space group.')
-  private int sgNum
+    /**
+     * --sg or --spaceGroupNumber Override the CIF space group.
+     */
+    @Option(names = ['--sg', '--spaceGroupNumber'], paramLabel = "-1", defaultValue = "-1",
+            description = 'Override the CIF space group.')
+    private int sgNum
 
-  /**
-   * --name or --spaceGroupName Override the CIF space group.
-   */
-  @Option(names = ['--name', '--spaceGroupName'], paramLabel = "", defaultValue = "",
-      description = 'Override the CIF space group.')
-  private String sgName
+    /**
+     * --fl or --fixLattice Override CIF parameters to satisfy lattice conditions.
+     */
+    @Option(names = ['--fl', '--fixLattice'], paramLabel = "false", defaultValue = "false",
+            description = 'Override CIF parameters to satisfy lattice conditions (Otherwise error).')
+    private boolean fixLattice
 
-  /**
-   * The final argument(s) should be a CIF file and an XYZ file with atom types.
-   */
-  @Parameters(arity = "1..2", paramLabel = "files",
-      description = "A CIF file and an XYZ file (currently limited to a single molecule).")
-  List<String> filenames = null
+    /**
+     * --name or --spaceGroupName Override the CIF space group.
+     */
+    @Option(names = ['--name', '--spaceGroupName'], paramLabel = "", defaultValue = "",
+            description = 'Override the CIF space group.')
+    private String sgName
 
-  /**
-   * CIFtoXYZ Constructor.
-   */
-  CIFtoXYZ() {
-    this(new Binding())
-  }
+    /**
+     * The final argument(s) should be a CIF file and an XYZ file with atom types.
+     */
+    @Parameters(arity = "1..2", paramLabel = "files",
+            description = "A CIF file and an XYZ file (currently limited to a single molecule).")
+    List<String> filenames = null
 
-  /**
-   * CIFtoXYZ Constructor.
-   * @param binding Groovy Binding to use.
-   */
-  CIFtoXYZ(Binding binding) {
-    super(binding)
-  }
+    /**
+     * Maximum atomic covalent radius for CDK Rebonder Tool
+     */
+    private static final double MAX_COVALENT_RADIUS = 2.0
 
-  /**
-   * Execute the script.
-   */
-  @Override
-  CIFtoXYZ run() {
+    /**
+     * Minimum bond distance for CDK Rebonder Tool
+     */
+    private static final double MIN_BOND_DISTANCE = 0.5
 
-    // Turn off CDK logging.
-    System.setProperty("cdk.logging.level", "fatal")
+    /**
+     * Atoms within covalent bond radii + tolerance will be bonded.
+     */
+    private static final double BOND_TOLERANCE = 0.2
 
-    // Turn off non-bonded interactions.
-    System.setProperty("vdwterm", "false")
-
-    if (!init()) {
-      return this
+    /**
+     * CIFtoXYZ Constructor.
+     */
+    CIFtoXYZ() {
+        this(new Binding())
     }
 
-    //TODO support concatenated CIF files (separated by "data_######").
-    CifCoreFile cifFile
-    Path path
-    if (filenames != null && filenames.size() == 2) {
-      path = Paths.get(filenames.get(0))
-      cifFile = CifIO.readFromPath(path).as(StandardSchemata.CIF_CORE)
-    } else {
-      logger.info(helpString())
-      return this
+    /**
+     * CIFtoXYZ Constructor.
+     * @param binding Groovy Binding to use.
+     */
+    CIFtoXYZ(Binding binding) {
+        super(binding)
     }
 
-    String modelFilename = path.toAbsolutePath().toString()
-    logger.info("\n Opening CIF file " + path)
+    /**
+     * Execute the script.
+     */
+    @Override
+    CIFtoXYZ run() {
 
-//    CifCoreBlock block = cifFile.firstBlock
-    for(CifCoreBlock block: cifFile.blocks) {
-      logger.info(format(" Number of Blocks: %d", cifFile.blocks.size()))
+        // Turn off CDK logging.
+        System.setProperty("cdk.logging.level", "fatal")
 
-      Chemical chemical = block.chemical
-      Column nameCommon = chemical.nameCommon
-      Column nameSystematic = chemical.nameSystematic
-      int rowCount = nameCommon.rowCount
-      if (rowCount > 1) {
-        logger.info(" Chemical components")
-        for (int i = 0; i < rowCount; i++) {
-          logger.info(format("  %s", nameCommon.get(i)))
-        }
-      } else if (rowCount > 0) {
-        logger.info(format(" Chemical component: %s", nameCommon.get(0)))
-      }
+        // Turn off non-bonded interactions.
+        System.setProperty("vdwterm", "false")
 
-      // Determine the space group.
-      Symmetry symmetry = block.symmetry
-      if (sgNum == -1 && sgName == "") {
-        if (symmetry.intTablesNumber.rowCount > 0) {
-          sgNum = symmetry.intTablesNumber.get(0)
-          logger.info(format(" CIF International Tables Number: %d", sgNum))
+        if (!init()) {
+            return this
         }
-        if (symmetry.spaceGroupNameH_M.rowCount > 0) {
-          sgName = symmetry.spaceGroupNameH_M.get(0)
-          logger.info(format(" CIF Hermann–Mauguin Space Group: %s", sgName))
-        }
-      } else {
-        if (sgNum != -1) {
-          logger.info(format(" Command line International Tables Number: %d", sgNum))
+
+        CifCoreFile cifFile
+        Path path
+        if (filenames != null && filenames.size() == 2) {
+            path = Paths.get(filenames.get(0))
+            cifFile = CifIO.readFromPath(path).as(StandardSchemata.CIF_CORE)
         } else {
-          logger.info(format(" Command line space group name: %s", sgName))
-        }
-      }
-
-      SpaceGroup sg
-      sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
-      if (sg == null) {
-        sg = SpaceGroupDefinitions.spaceGroupFactory(sgNum)
-      }
-
-      // Fall back to P1.
-      if (sg == null) {
-        logger.warning(" The space group could not be determined from the CIF file (using P1).")
-        sg = SpaceGroupDefinitions.spaceGroupFactory(1)
-      }
-
-      Cell cell = block.cell
-      double a = cell.lengthA.get(0)
-      double b = cell.lengthB.get(0)
-      double c = cell.lengthC.get(0)
-      double alpha = cell.angleAlpha.get(0)
-      double beta = cell.angleBeta.get(0)
-      double gamma = cell.angleGamma.get(0)
-
-      Crystal crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
-      logger.info(" New crystal:")
-      logger.info(crystal.toString())
-
-      AtomSite atomSite = block.atomSite
-      Column label = atomSite.label
-      Column typeSymbol = atomSite.typeSymbol
-      Column fractX = atomSite.fractX
-      Column fractY = atomSite.fractY
-      Column fractZ = atomSite.fractZ
-
-      int nAtoms = label.getRowCount()
-      logger.info(format("\n Number of atoms: %d", nAtoms))
-      Atom[] atoms = new Atom[nAtoms]
-
-      // Define per atom information for the PDB file.
-      String resName = "CIF"
-      int resID = 1
-      double occupancy = 1.0
-      double bfactor = 1.0
-      char altLoc = ' '
-      char chain = 'A'
-      String segID = "A"
-      String[] symbols = new String[nAtoms]
-
-      // Loop over atoms.
-      for (int i = 0; i < nAtoms; i++) {
-        symbols[i] = typeSymbol.get(i)
-        double x = fractX.get(i)
-        double y = fractY.get(i)
-        double z = fractZ.get(i)
-        double[] xyz = [x, y, z]
-        crystal.toCartesianCoordinates(xyz, xyz)
-        atoms[i] = new Atom(i + 1, label.get(i), altLoc, xyz, resName, resID, chain, occupancy,
-                bfactor, segID)
-        atoms[i].setHetero(true)
-      }
-
-      // Determine where to save results.
-      File saveDir = baseDir
-      File cif = new File(modelFilename)
-      String cifName = cif.getAbsolutePath()
-      if (saveDir == null || !saveDir.exists() || !saveDir.isDirectory() || !saveDir.canWrite()) {
-        saveDir = new File(FilenameUtils.getFullPath(cifName))
-      }
-      String dirName = saveDir.toString() + File.separator
-      String fileName = FilenameUtils.getName(cifName)
-
-      boolean savePDB = true
-      if (filenames.size() > 1) {
-        savePDB = false
-        // Open the XYZ file (with electrostatics turned off).
-        System.setProperty("mpoleterm", "false")
-        MolecularAssembly[] assemblies = potentialFunctions.openAll(filenames.get(1))
-        System.clearProperty("mpoleterm")
-
-        setActiveAssembly(assemblies[0])
-        Atom[] xyzAtoms = activeAssembly.getAtomArray()
-        int nXYZAtoms = xyzAtoms.length
-
-        // Used to determine if the CIF structure is missing hydrogen later on.
-        int numHydrogens = 0
-        for (Atom atom in xyzAtoms) {
-          if (atom.isHydrogen()) {
-            numHydrogens++
-          }
+            logger.info(helpString())
+            return this
         }
 
-        //TODO: Add >1 ASU
-        if (nAtoms == nXYZAtoms || (nAtoms + numHydrogens) == nXYZAtoms) {
-          AtomContainer cifCDKAtoms = new AtomContainer()
-          AtomContainer xyzCDKAtoms = new AtomContainer()
-          for (int i = 0; i < nAtoms; i++) {
-            cifCDKAtoms.addAtom(new org.openscience.cdk.Atom(symbols[i],
-                    new Point3d(atoms[i].getXYZ(null))))
-          }
-          AtomContainer nullCDKAtoms = new AtomContainer()
+        String modelFilename = path.toAbsolutePath().toString()
+        logger.info("\n Opening CIF file " + path)
+        int numFailed = 0
 
-          for (IAtom atom in cifCDKAtoms.atoms()) {
-            if (atom.toString() == null) {
-              nullCDKAtoms.addAtom(atom)
-            }
-          }
-          cifCDKAtoms.remove(nullCDKAtoms)
-
-          for (Atom atom : xyzAtoms) {
-            String atomName = getSymbol(atom.getAtomType().atomicNumber)
-            xyzCDKAtoms.addAtom(new org.openscience.cdk.Atom(atomName, new Point3d(atom.getXYZ(null))))
-          }
-
-          // Add known XYZ bonds; a limitation is that bonds all are given a Bond order of 1.
-          List<Bond> bonds = activeAssembly.getBondList()
-          Order order = Order.SINGLE
-          int xyzBonds = bonds.size()
-          for (Bond bond : bonds) {
-            xyzCDKAtoms.addBond(bond.getAtom(0).xyzIndex - 1, bond.getAtom(1).xyzIndex - 1, order)
-          }
-
-          // Assign CDK atom types for the XYZ molecule.
-          AtomTypeFactory factory = AtomTypeFactory.getInstance(
-                  "org/openscience/cdk/config/data/jmol_atomtypes.txt",
-                  xyzCDKAtoms.getBuilder())
-
-          for (IAtom atom : xyzCDKAtoms.atoms()) {
-            String atomTypeName = atom.getAtomTypeName()
-            if (atomTypeName == null || atomTypeName.length() == 0) {
-              IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
-              if (types.length > 0) {
-                IAtomType atomType = types[0]
-                atom.setAtomTypeName(atomType.getAtomTypeName())
-              } else {
-                logger.info(" No atom type found for " + atom.toString())
-              }
-            }
-            factory.configure(atom)
-          }
-
-          // Compute bonds for CIF molecule.
-          factory = AtomTypeFactory.getInstance(
-                  "org/openscience/cdk/config/data/jmol_atomtypes.txt",
-                  cifCDKAtoms.getBuilder())
-
-          for (IAtom atom : cifCDKAtoms.atoms()) {
-            String atomTypeName = atom.getAtomTypeName()
-            if (atomTypeName == null || atomTypeName.length() == 0) {
-              IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
-              if (types.length > 0) {
-                IAtomType atomType = types[0]
-                atom.setAtomTypeName(atomType.getAtomTypeName())
-              } else {
-                logger.info(" No atom type found for " + atom.toString())
-              }
-            }
-            factory.configure(atom)
-          }
-
-          double maxCovalentRadius = 2.0
-          double minBondDistance = 0.5
-          double bondTolerance = 0.5
-          RebondTool rebonder = new RebondTool(maxCovalentRadius, minBondDistance, bondTolerance)
-          rebonder.rebond(cifCDKAtoms)
-
-          int cifBonds = cifCDKAtoms.bondCount
-
-          // Number of bonds matches.
-          if (cifBonds == xyzBonds) {
-            Pattern pattern =
-                    VentoFoggia.findIdentical(xyzCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
-            int[] p = pattern.match(cifCDKAtoms)
-            if (p != null && p.length == nAtoms) {
-              // Used matched atoms to update the positions of the XYZ file atoms.
-              for (int i = 0; i < p.length; i++) {
-                // logger.info(format(" %d XYZ %s -> CIF %s", i, xyzCDKAtoms.getAtom(i).getSymbol(), cifCDKAtoms.getAtom(p[i]).getSymbol()))
-                Point3d point3d = cifCDKAtoms.getAtom(p[i]).getPoint3d()
-                xyzAtoms[i].setXYZ(point3d.x, point3d.y, point3d.z)
-              }
-            } else {
-              logger.info(" CIF and XYZ files don't match.")
-              savePDB = true
-            }
-
-          } else if ((cifBonds + numHydrogens) % xyzBonds == 0) {
-            // Hydrogens most likely missing from file.
-            logger.info(" CIF may contain implicit hydrogen -- attempting to patch.")
-            // Match heavy atoms between CIF and XYZ
-            Pattern pattern = VentoFoggia.
-                    findSubstructure(cifCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
-            int[] p = pattern.match(xyzCDKAtoms)
-            if (p != null && p.length == nAtoms) {
-              // Used matched atoms to update the positions of the XYZ file atoms.
-              for (int i = 0; i < p.length; i++) {
-                Point3d point3d = cifCDKAtoms.getAtom(i).getPoint3d()
-                xyzAtoms[p[i]].setXYZ(point3d.x, point3d.y, point3d.z)
-              }
-              // Add in hydrogen atoms
-              Atom lastKnownAtom1 = null
-              int knownCount = 0
-              for (Atom hydrogen in xyzAtoms) {
-                if (hydrogen.isHydrogen()) {
-                  Bond bond0 = hydrogen.getBonds()[0]
-                  Atom atom1 = bond0.get1_2(hydrogen)
-                  double angle0_2 = 0
-                  List<Angle> anglesList = hydrogen.getAngles() // Same as bond
-                  Atom atom2 = null
-                  switch (anglesList.size()) {
-                    case 0:
-                      // H-Cl No angles
-                      logger.info("Structure may contain only two atoms. Not supported yet.")
-                      break
-                    case 1:
-                      // H-O=C Need torsion
-                      for (Angle angle in anglesList) {
-                        atom2 = angle.get1_3(hydrogen)
-                        if (atom2 != null && !atom2.isHydrogen()) {
-                          angle0_2 = angle.angleType.angle[0]
-                        }
-                        if (angle0_2 != 0) {
-                          //if angle0_2 is found then no need to look for another atom.
-                          break
-                        }
-                      }
-                      List<Bond> bonds2 = atom2.getBonds()
-                      Atom atom3 = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
-                      double diAng =
-                              dihedralAngle(hydrogen.getXYZ(null), atom1.getXYZ(null),
-                                      atom2.getXYZ(null), atom3.getXYZ(null))
-                      intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom3,
-                              Math.toDegrees(diAng), 0)
-                      break
-                    default:
-                      // H-C(-C)(-C)-C
-                      Atom atom2B = null
-                      double angle0_2B = 0
-                      Atom proposedAtom
-                      double proposedAngle = 0
-                      int chiral = 1
-                      for (Angle angle in anglesList) {
-                        proposedAtom = angle.get1_3(hydrogen)
-                          if (proposedAtom != null && !proposedAtom.isHydrogen()) {
-                            proposedAngle = angle.angleType.angle[0]
-                          }
-                          if (proposedAngle != 0) {
-                            // If angle1_3 is found then no need to look for another atom.
-                            if (angle0_2 != 0) {
-                              atom2B = proposedAtom
-                              angle0_2B = proposedAngle
-                            } else {
-                              atom2 = proposedAtom
-                              angle0_2 = proposedAngle
-                            }
-                            proposedAngle = 0.0
-                          }
-                        if (angle0_2 != 0 && angle0_2B != 0) {
-                          break
-                        }
-                      }
-                      if (lastKnownAtom1 == null || lastKnownAtom1 != atom1) {
-                        lastKnownAtom1 = atom1
-                        knownCount = 0
-                      } else {
-                        knownCount++
-                      }
-                      if (angle0_2B == 0.0) {
-                        // Hydrogen position depends on other hydrogens, use generic location
-                        chiral = 0
-                        List<Bond> bonds2 = atom2.getBonds()
-                        atom2B = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
-                        // Evenly space out hydrogens
-                        angle0_2B = 180.0 - 120.0 * knownCount
-                      } else if (anglesList.size() == 2) {
-                        // Trigonal hydrogen use equipartition between selected atoms
-                        chiral = 3
-                      } else if (knownCount == 1) {
-                        // Already created one hydrogen (chiral = 1), use other.
-                        chiral = -1
-                      }
-                      //TODO decern whether to use chiral = 1 or -1 when angles are to three heavy atoms.
-                      intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom2B, angle0_2B, chiral)
-                  }
+        for (CifCoreBlock block : cifFile.blocks) {
+            logger.info(" Block ID: " + block.getBlockHeader())
+            Chemical chemical = block.chemical
+            Column nameCommon = chemical.nameCommon
+            Column nameSystematic = chemical.nameSystematic
+            int rowCount = nameCommon.rowCount
+            if (rowCount > 1) {
+                logger.info(" Chemical components")
+                for (int i = 0; i < rowCount; i++) {
+                    logger.info(format("  %s", nameCommon.get(i)))
                 }
-              }
-            } else {
-              logger.info(" Could not match heavy atoms between CIF and XYZ.")
-              savePDB = true
+            } else if (rowCount > 0) {
+                logger.info(format(" Chemical component: %s", nameCommon.get(0)))
             }
-          } else {
-            logger.info(format(" CIF (%d) and XYZ (%d) have a different number of bonds.", cifBonds,
-                    xyzBonds))
-            savePDB = true
-          }
-        } else {
-          logger.info(format(" CIF (%d) and XYZ (%d) files have different numbers of atoms.", nAtoms,
-                  nXYZAtoms))
-          savePDB = true
+
+            // Determine the space group.
+            Symmetry symmetry = block.symmetry
+            if (sgNum == -1 && sgName == "") {
+                if (symmetry.intTablesNumber.rowCount > 0) {
+                    sgNum = symmetry.intTablesNumber.get(0)
+                    logger.info(format(" CIF International Tables Number: %d", sgNum))
+                }
+                if (symmetry.spaceGroupNameH_M.rowCount > 0) {
+                    sgName = symmetry.spaceGroupNameH_M.get(0)
+                    logger.info(format(" CIF Hermann–Mauguin Space Group: %s", sgName))
+                }
+            } else {
+                if (sgNum != -1) {
+                    logger.info(format(" Command line International Tables Number: %d", sgNum))
+                } else {
+                    logger.info(format(" Command line space group name: %s", sgName))
+                }
+            }
+
+            SpaceGroup sg
+            sg = SpaceGroupDefinitions.spaceGroupFactory(sgName)
+            if (sg == null) {
+                logger.finer(" Space group name not found. Attempting to use space group number.")
+                sg = SpaceGroupDefinitions.spaceGroupFactory(sgNum)
+            }
+
+            // Fall back to P1.
+            if (sg == null) {
+                logger.warning(" The space group could not be determined from the CIF file (using P1).")
+                sg = SpaceGroupDefinitions.spaceGroupFactory(1)
+            }
+
+            Cell cell = block.cell
+            double a = cell.lengthA.get(0)
+            double b = cell.lengthB.get(0)
+            double c = cell.lengthC.get(0)
+            double alpha = cell.angleAlpha.get(0)
+            double beta = cell.angleBeta.get(0)
+            double gamma = cell.angleGamma.get(0)
+            LatticeSystem latticeSystem = sg.latticeSystem
+            double[] latticeParameters = [a, b, c, alpha, beta, gamma]
+            Crystal crystal
+            if (latticeSystem.validParameters(a, b, c, alpha, beta, gamma)) {
+                crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
+            } else {
+                if (fixLattice) {
+                    logger.warning(" Attempting to patch disagreement between lattice system and lattice parameters.")
+                    double[] newLatticeParameters = latticeSystem.fixParameters(a, b, c, alpha, beta, gamma)
+                    if (newLatticeParameters == latticeParameters) {
+                        logger.warning(" Conversion Failed: The proposed lattice parameters for " + sg.pdbName
+                                + " do not satisfy the " + latticeSystem + ".")
+                        numFailed++
+                        continue
+                    } else {
+                        a = newLatticeParameters[0]
+                        b = newLatticeParameters[1]
+                        c = newLatticeParameters[2]
+                        alpha = newLatticeParameters[3]
+                        beta = newLatticeParameters[4]
+                        gamma = newLatticeParameters[5]
+                        crystal = new Crystal(a, b, c, alpha, beta, gamma, sg.pdbName)
+                    }
+                } else {
+                    logger.warning(" Conversion Failed: The proposed lattice parameters for " + sg.pdbName
+                            + " do not satisfy the " + latticeSystem + ".")
+                    logger.info(" Use \"--fl\" flag to attempt to fix automatically.")
+                    numFailed++
+                    continue
+                }
+            }
+            logger.info(" New Crystal: " + crystal.toString())
+
+            AtomSite atomSite = block.atomSite
+            Column label = atomSite.label
+            Column typeSymbol = atomSite.typeSymbol
+            Column fractX = atomSite.fractX
+            Column fractY = atomSite.fractY
+            Column fractZ = atomSite.fractZ
+
+            int nAtoms = label.getRowCount()
+            logger.info(format("\n Number of atoms: %d", nAtoms))
+            Atom[] atoms = new Atom[nAtoms]
+
+            // Define per atom information for the PDB file.
+            String resName = "CIF"
+            int resID = 1
+            double occupancy = 1.0
+            double bfactor = 1.0
+            char altLoc = ' '
+            char chain = 'A'
+            String segID = "A"
+            String[] symbols = new String[nAtoms]
+
+            // Loop over atoms.
+            for (int i = 0; i < nAtoms; i++) {
+                symbols[i] = typeSymbol.get(i)
+                double x = fractX.get(i)
+                double y = fractY.get(i)
+                double z = fractZ.get(i)
+                double[] xyz = [x, y, z]
+                crystal.toCartesianCoordinates(xyz, xyz)
+                atoms[i] = new Atom(i + 1, label.get(i), altLoc, xyz, resName, resID, chain, occupancy,
+                        bfactor, segID)
+                atoms[i].setHetero(true)
+            }
+
+            // Determine where to save results.
+            File saveDir = baseDir
+            File cif = new File(modelFilename)
+            String cifName = cif.getAbsolutePath()
+            if (saveDir == null || !saveDir.exists() || !saveDir.isDirectory() || !saveDir.canWrite()) {
+                saveDir = new File(FilenameUtils.getFullPath(cifName))
+            }
+            String dirName = saveDir.toString() + File.separator
+            String fileName = FilenameUtils.getName(cifName)
+
+            boolean savePDB = true
+            if (filenames.size() > 1) {
+                savePDB = false
+                // Open the XYZ file (with electrostatics turned off).
+                System.setProperty("mpoleterm", "false")
+                MolecularAssembly[] assemblies = potentialFunctions.openAll(filenames.get(1))
+                System.clearProperty("mpoleterm")
+
+                setActiveAssembly(assemblies[0])
+                activeAssembly.setName(block.getBlockHeader())
+                Atom[] xyzAtoms = activeAssembly.getAtomArray()
+                int nXYZAtoms = xyzAtoms.length
+
+                // Used to determine if the CIF structure is missing hydrogen later on.
+                int numHydrogens = 0
+                for (Atom atom in xyzAtoms) {
+                    if (atom.isHydrogen()) {
+                        numHydrogens++
+                    }
+                }
+
+                //TODO: Add >1 ASU
+                boolean itsFine = false
+                int zPrime
+                if (nAtoms % nXYZAtoms == 0) {
+                    zPrime = (int) (nAtoms / nXYZAtoms)
+                    itsFine = true
+                } else if ((nAtoms + numHydrogens) % nXYZAtoms == 0) {
+                    zPrime = (int) ((nAtoms + numHydrogens) / nXYZAtoms)
+                    itsFine = true
+                } else {
+                    zPrime = 1
+                }
+                if (zPrime > 1) {
+                    logger.info(format(" CIF may contain more than one species (%d) -- attempting to identify.", zPrime))
+                }
+
+                MolecularAssembly outputAssembly = new MolecularAssembly(block.getBlockHeader())
+
+                if (nAtoms == nXYZAtoms || (nAtoms + numHydrogens) == nXYZAtoms || itsFine) {
+                    // Set up XYZ file contents as CDK variable
+                    AtomContainer xyzCDKAtoms = new AtomContainer()
+                    for (Atom atom : xyzAtoms) {
+                        String atomName = getSymbol(atom.getAtomType().atomicNumber)
+                        xyzCDKAtoms.addAtom(new org.openscience.cdk.Atom(atomName, new Point3d(atom.getXYZ(null))))
+                    }
+
+                    // Add known XYZ bonds; a limitation is that bonds all are given a Bond order of 1.
+                    List<Bond> bonds = activeAssembly.getBondList()
+                    Order order = Order.SINGLE
+                    int xyzBonds = bonds.size()
+                    for (Bond bond : bonds) {
+                        xyzCDKAtoms.addBond(bond.getAtom(0).xyzIndex - 1, bond.getAtom(1).xyzIndex - 1, order)
+                    }
+
+                    // Assign CDK atom types for the XYZ molecule.
+                    AtomTypeFactory factory = AtomTypeFactory.getInstance(
+                            "org/openscience/cdk/config/data/jmol_atomtypes.txt",
+                            xyzCDKAtoms.getBuilder())
+
+                    for (IAtom atom : xyzCDKAtoms.atoms()) {
+                        String atomTypeName = atom.getAtomTypeName()
+                        if (atomTypeName == null || atomTypeName.length() == 0) {
+                            IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
+                            if (types.length > 0) {
+                                IAtomType atomType = types[0]
+                                atom.setAtomTypeName(atomType.getAtomTypeName())
+                            } else {
+                                logger.info(" No atom type found for " + atom.toString())
+                            }
+                        }
+                        factory.configure(atom)
+                    }
+
+                    int nAUatoms = (int) (nAtoms / zPrime)
+                    int[][] zIndices = new int[zPrime][nAUatoms]
+                    int counter = 0
+                    if(zPrime == 1){
+                        for(int i = 0; i < nAtoms; i++){
+                            zIndices[0][i] = atoms[i].getIndex() - 1
+                        }
+                    }else {
+                        // Bond atoms in CIF file.
+                        bondAtoms(atoms)
+
+                        List<Atom> atomPool = new ArrayList<>()
+                        for (int i = 0; i < atoms.size(); i++) {
+                            atomPool.add(atoms[i])
+                        }
+
+
+                        try {
+                            while (!atomPool.isEmpty()) {
+                                List<Atom> molecule = new ArrayList<>()
+                                collectAtoms(atomPool.get(0), molecule)
+                                List<Integer> indices = new ArrayList<>()
+                                while (molecule.size() > 0) {
+                                    Atom atom = molecule.remove(0)
+                                    indices.add(atom.getIndex())
+                                    atomPool.remove(atom)
+                                }
+                                if (counter >= zPrime) {
+                                    logger.warning(format(" Molecule %d of %d detected, but %d atoms are ready and %d remain (%d atoms per molecule, %d atoms in CIF). ",
+                                            counter + 1, zPrime, indices.size(), atomPool.size(), nAUatoms, nAtoms))
+                                }
+                                zIndices[counter++] = indices.stream().mapToInt(i -> i - 1).toArray()
+                            }
+                        } catch (Exception e) {
+                            logger.warning(" Failed to identify species within the asymmetric unit.")
+                            logger.info(e.toString())
+                            numFailed++
+                            continue
+                        }
+                    }
+
+                    // Set up CIF file contents as CDK variable
+                    AtomContainer[] cifCDKAtomsArr = new AtomContainer[zPrime]
+                    AtomContainer cifCDKAtoms = new AtomContainer()
+                    int atomIndex = 1
+                    for (int i = 0; i < zPrime; i++) {
+                        cifCDKAtomsArr[i] = new AtomContainer()
+                        for (int j = 0; j < nAUatoms; j++) {
+                            cifCDKAtomsArr[i].addAtom(new org.openscience.cdk.Atom(symbols[zIndices[i][j]],
+                                    new Point3d(atoms[zIndices[i][j]].getXYZ(null))))
+                        }
+                        AtomContainer nullCDKAtoms = new AtomContainer()
+
+                        for (IAtom atom in cifCDKAtomsArr[i].atoms()) {
+                            if (atom.toString() == null) {
+                                nullCDKAtoms.addAtom(atom)
+                            }
+                        }
+                        cifCDKAtomsArr[i].remove(nullCDKAtoms)
+
+
+                        // Compute bonds for CIF molecule.
+                        factory = AtomTypeFactory.getInstance(
+                                "org/openscience/cdk/config/data/jmol_atomtypes.txt",
+                                cifCDKAtomsArr[i].getBuilder())
+                        for (IAtom atom : cifCDKAtomsArr[i].atoms()) {
+                            String atomTypeName = atom.getAtomTypeName()
+                            if (atomTypeName == null || atomTypeName.length() == 0) {
+                                IAtomType[] types = factory.getAtomTypes(atom.getSymbol())
+                                if (types.length > 0) {
+                                    IAtomType atomType = types[0]
+                                    atom.setAtomTypeName(atomType.getAtomTypeName())
+                                } else {
+                                    logger.info(" No atom type found for " + atom.toString())
+                                }
+                            }
+                            factory.configure(atom)
+                        }
+
+                        RebondTool rebonder = new RebondTool(MAX_COVALENT_RADIUS, MIN_BOND_DISTANCE, BOND_TOLERANCE)
+                        rebonder.rebond(cifCDKAtomsArr[i])
+
+                        int cifBonds = cifCDKAtomsArr[i].getBondCount();
+
+                        // Number of bonds matches.
+                        if (cifBonds % xyzBonds == 0) {
+                            Pattern pattern =
+                                    VentoFoggia.findIdentical(xyzCDKAtoms, AtomMatcher.forElement(), BondMatcher.forAny())
+                            int[] p = pattern.match(cifCDKAtomsArr[i])
+                            if (p != null && p.length == nAUatoms) {
+                                // Used matched atoms to update the positions of the XYZ file atoms.
+                                for (int j = 0; j < p.length; j++) {
+                                    // logger.info(format(" %d XYZ %s -> CIF %s", j, xyzCDKAtoms.getAtom(j).getSymbol(), cifCDKAtoms.getAtom(p[j]).getSymbol()))
+                                    Point3d point3d = cifCDKAtomsArr[i].getAtom(p[j]).getPoint3d()
+                                    xyzAtoms[j].setXYZ(point3d.x, point3d.y, point3d.z)
+                                }
+                            } else {
+                                logger.warning(format(" CIF (%d) and XYZ (%d) files don't match.", p.length, nAtoms))
+                                savePDB = true
+                            }
+
+                        } else if ((cifBonds + numHydrogens) % xyzBonds == 0) {
+                            // Hydrogens most likely missing from file.
+                            logger.info(" CIF may contain implicit hydrogen -- attempting to patch.")
+                            // Match heavy atoms between CIF and XYZ
+                            Pattern pattern = VentoFoggia.
+                                    findSubstructure(cifCDKAtomsArr[i], AtomMatcher.forElement(), BondMatcher.forAny())
+                            int[] p = pattern.match(xyzCDKAtoms)
+                            if (p != null && p.length == nAUatoms) {
+                                // Used matched atoms to update the positions of the XYZ file atoms.
+                                for (int j = 0; j < p.length; j++) {
+                                    Point3d point3d = cifCDKAtomsArr[i].getAtom(j).getPoint3d()
+                                    xyzAtoms[p[j]].setXYZ(point3d.x, point3d.y, point3d.z)
+                                }
+                                // Add in hydrogen atoms
+                                Atom lastKnownAtom1 = null
+                                int knownCount = 0
+                                for (Atom hydrogen in xyzAtoms) {
+                                    if (hydrogen.isHydrogen()) {
+                                        Bond bond0 = hydrogen.getBonds()[0]
+                                        Atom atom1 = bond0.get1_2(hydrogen)
+                                        double angle0_2 = 0
+                                        List<Angle> anglesList = hydrogen.getAngles() // Same as bond
+                                        Atom atom2 = null
+                                        switch (anglesList.size()) {
+                                            case 0:
+                                                // H-Cl No angles
+                                                logger.info("Structure may contain only two atoms. Not supported yet.")
+                                                break
+                                            case 1:
+                                                // H-O=C Need torsion
+                                                for (Angle angle in anglesList) {
+                                                    atom2 = angle.get1_3(hydrogen)
+                                                    if (atom2 != null && !atom2.isHydrogen()) {
+                                                        angle0_2 = angle.angleType.angle[0]
+                                                    }
+                                                    if (angle0_2 != 0) {
+                                                        //if angle0_2 is found then no need to look for another atom.
+                                                        break
+                                                    }
+                                                }
+                                                List<Bond> bonds2 = atom2.getBonds()
+                                                Atom atom3 = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
+                                                double diAng =
+                                                        dihedralAngle(hydrogen.getXYZ(null), atom1.getXYZ(null),
+                                                                atom2.getXYZ(null), atom3.getXYZ(null))
+                                                intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom3,
+                                                        Math.toDegrees(diAng), 0)
+                                                break
+                                            default:
+                                                // H-C(-C)(-C)-C
+                                                Atom atom2B = null
+                                                double angle0_2B = 0
+                                                Atom proposedAtom
+                                                double proposedAngle = 0
+                                                int chiral = 1
+                                                for (Angle angle in anglesList) {
+                                                    proposedAtom = angle.get1_3(hydrogen)
+                                                    if (proposedAtom != null && !proposedAtom.isHydrogen()) {
+                                                        proposedAngle = angle.angleType.angle[0]
+                                                    }
+                                                    if (proposedAngle != 0) {
+                                                        // If angle1_3 is found then no need to look for another atom.
+                                                        if (angle0_2 != 0) {
+                                                            atom2B = proposedAtom
+                                                            angle0_2B = proposedAngle
+                                                        } else {
+                                                            atom2 = proposedAtom
+                                                            angle0_2 = proposedAngle
+                                                        }
+                                                        proposedAngle = 0.0
+                                                    }
+                                                    if (angle0_2 != 0 && angle0_2B != 0) {
+                                                        break
+                                                    }
+                                                }
+                                                if (lastKnownAtom1 == null || lastKnownAtom1 != atom1) {
+                                                    lastKnownAtom1 = atom1
+                                                    knownCount = 0
+                                                } else {
+                                                    knownCount++
+                                                }
+                                                if (angle0_2B == 0.0.toDouble()) {
+                                                    // Hydrogen position depends on other hydrogens, use generic location
+                                                    chiral = 0
+                                                    List<Bond> bonds2 = atom2.getBonds()
+                                                    atom2B = (atom1 == bonds2[0].get1_2(atom2)) ? bonds2[1].get1_2(atom2) : bonds2[0].get1_2(atom2)
+                                                    // Evenly space out hydrogens
+                                                    angle0_2B = 180.0 - 120.0 * knownCount
+                                                } else if (anglesList.size() == 2) {
+                                                    // Trigonal hydrogen use equipartition between selected atoms
+                                                    chiral = 3
+                                                } else if (knownCount == 1) {
+                                                    // Already created one hydrogen (chiral = 1), use other.
+                                                    chiral = -1
+                                                }
+                                                //TODO discern whether to use chiral = 1 or -1 when angles are to three heavy atoms.
+                                                intxyz(hydrogen, atom1, bond0.bondType.distance, atom2, angle0_2, atom2B, angle0_2B, chiral)
+                                        }
+                                    }
+                                }
+                            } else {
+                                logger.warning(" Could not match heavy atoms between CIF and XYZ.")
+                                savePDB = true
+                            }
+                        } else {
+                            logger.warning(format(" CIF (%d) and XYZ (%d) have a different number of bonds.", cifBonds,
+                                    xyzBonds))
+                            savePDB = true
+                        }
+                        cifCDKAtoms.add(cifCDKAtomsArr[i])
+                        Molecule molecule = new Molecule("Molecule-" + i)
+                        List<Atom> atomList = new ArrayList<>()
+                        for (int j = 0; j < nXYZAtoms; j++) {
+                            Atom atom = xyzAtoms[j]
+                            Atom molAtom = new Atom(atomIndex++, atom.getName(), atom.getAtomType(), atom.getXYZ(null))
+                            atomList.add(molAtom)
+                        }
+                        List<Bond> bondList = activeAssembly.getBondList()
+                        for (Bond bond : bondList) {
+                            Atom a1 = bond.getAtom(0)
+                            Atom a2 = bond.getAtom(1)
+                            Atom newA1 = atomList.get(a1.getIndex() - 1)
+                            Atom newA2 = atomList.get(a2.getIndex() - 1)
+                            Bond bond2 = new Bond(newA1, newA2)
+                            bond2.setBondType(bond.getBondType())
+                        }
+                        for (int j = 0; j < atomList.size(); j++) {
+                            molecule.addMSNode(atomList.get(j))
+                        }
+                        outputAssembly.addMSNode(molecule)
+                    }
+                } else {
+                    logger.warning(format(" CIF (%d) and XYZ (%d) files have different numbers of atoms.", nAtoms,
+                            nXYZAtoms))
+                    savePDB = true
+                }
+                // If no atoms, then conversion has failed... use active assembly
+                if (outputAssembly.getAtomList().size() < 1) {
+                    outputAssembly = activeAssembly
+                }
+
+                if (savePDB) {
+                    // Save a PDB file if there is no XYZ file supplied.
+                    fileName = FilenameUtils.removeExtension(fileName) + ".pdb"
+                    File saveFile = new File(dirName + fileName)
+
+                    // Write out PDB file.
+                    PDBFilter pdbFilter = new PDBFilter(saveFile, outputAssembly, null, null)
+                    //PDBs should only be written out when an error occurs... Each individually might make it easier to debug.
+                    pdbFilter.writeFile(saveFile, false)
+                    logger.info("\n Saved PDB file to " + saveFile.getAbsolutePath())
+                } else {
+                    // Update the active molecular assembly to use the CIF space group and unit cell.
+                    outputAssembly.setForceField(activeAssembly.getForceField())
+                    outputAssembly.setPotential(activeAssembly.getPotentialEnergy())
+                    outputAssembly.getPotentialEnergy().setCrystal(crystal)
+                    // Choose a location to save the file.
+                    File saveFile
+                    fileName = FilenameUtils.removeExtension(fileName)
+                    if (cifFile.blocks.size() > 1) {
+                        if (zPrime > 1) {
+                            fileName += "_z" + zPrime.toString()
+                        }
+                        // Concatenated CIF files may contain more than one space group.
+                        fileName = fileName + "_" + sg.shortName.replaceAll("\\/", "") + ".arc"
+                        saveFile = new File(dirName + fileName)
+                    } else {
+                        // If only structure, create new file on each run.
+                        fileName = fileName + ".xyz"
+                        saveFile = XYZFilter.version(new File(dirName + fileName))
+                    }
+
+                    // Write out the result.
+                    XYZFilter xyzFilter = new XYZFilter(saveFile, outputAssembly, null, null)
+                    xyzFilter.writeFile(saveFile, true)
+                    logger.info("\n Saved XYZ file:        " + saveFile.getAbsolutePath())
+
+                    // Write out a property file.
+                    fileName = FilenameUtils.removeExtension(fileName) + ".properties"
+                    File propertyFile = new File(dirName + fileName)
+                    if (!propertyFile.exists()) {
+                        FileWriter fw = new FileWriter(propertyFile, false)
+                        BufferedWriter bw = new BufferedWriter(fw)
+                        ForceField forceField = outputAssembly.getForceField()
+                        String parameters = forceField.getString("parameters", "none")
+                        if (parameters != null && !parameters.equalsIgnoreCase("none")) {
+                            bw.write(format("parameters %s\n", parameters))
+                        }
+                        String patch = forceField.getString("patch", "none")
+                        if (patch != null && !patch.equalsIgnoreCase("none")) {
+                            bw.write(format("patch %s\n", patch))
+                        }
+                        bw.write(format("spacegroup %s\n", crystal.spaceGroup.shortName))
+                        if(zPrime > 1){
+                            bw.write("intermolecular-softcore true")
+                        }
+
+                        bw.close()
+                        logger.info("\n Saved properties file: " + propertyFile.getAbsolutePath())
+                    } else {
+                        logger.info("\n Property file already exists:  " + propertyFile.getAbsolutePath())
+                    }
+                }
+                //Reset space group for next block
+                sgNum = -1
+                sgName = ""
+            }
+            if (numFailed > 0) {
+                logger.info(format(" %d CIF files were not successfully converted.", numFailed))
+            }
         }
-      }
-
-      setVersioning(PREFIX)
-      if (savePDB) {
-        // Save a PDB file if there is no XYZ file supplied.
-        fileName = FilenameUtils.removeExtension(fileName) + ".pdb"
-        File saveFile = version(new File(dirName + fileName))
-
-        // Write out PDB file.
-        FileWriter fw = new FileWriter(saveFile, false)
-        BufferedWriter bw = new BufferedWriter(fw)
-        bw.write(crystal.toCRYST1())
-        for (int i = 0; i < nAtoms; i++) {
-          bw.write(toPDBAtomLine(atoms[i]))
-        }
-        bw.write("END\n")
-        bw.close()
-        logger.info("\n Saved PDB file to " + saveFile.getAbsolutePath())
-      } else {
-        // Update the active molecular assembly to use the CIF space group and unit cell.
-        activeAssembly.getPotentialEnergy().setCrystal(crystal)
-        // Choose a location to save the file.
-        fileName = FilenameUtils.removeExtension(fileName) + ".xyz"
-        File saveFile = version(new File(dirName + fileName))
-
-        // Write out the result.
-        potentialFunctions.saveAsXYZ(activeAssembly, saveFile)
-        logger.info("\n Saved XYZ file:        " + saveFile.getAbsolutePath())
-
-        // Write out a property file.
-        fileName = FilenameUtils.removeExtension(fileName) + ".properties"
-        File propertyFile = version(new File(dirName + fileName))
-        if (!propertyFile.exists()) {
-          FileWriter fw = new FileWriter(propertyFile, false)
-          BufferedWriter bw = new BufferedWriter(fw)
-          ForceField forceField = activeAssembly.getForceField()
-          String parameters = forceField.getString("parameters", "none")
-          if (parameters != null && !parameters.equalsIgnoreCase("none")) {
-            bw.write(format("parameters %s\n", parameters))
-          }
-          String patch = forceField.getString("patch", "none")
-          if (patch != null && !patch.equalsIgnoreCase("none")) {
-            bw.write(format("patch %s\n", patch))
-          }
-          bw.write(format("spacegroup %s\n", crystal.spaceGroup.shortName))
-
-          bw.close()
-          logger.info("\n Saved properties file: " + propertyFile.getAbsolutePath())
-        } else {
-          logger.info("\n Property file already exists:  " + propertyFile.getAbsolutePath())
-        }
-      }
+        return this
     }
 
-    return this
-  }
+    /**
+     * Add bonds between atoms.
+     *
+     * @param atoms To potentially be bonded together.
+     */
+    private static void bondAtoms(Atom[] atoms) {
+        for (int i = 0; i < atoms.size(); i++) {
+            Atom atom1 = atoms[i]
+            String atomIelement = getAtomElement(atom1)
+            double radiusI = getCovalentRadius(atomIelement)
+            if (radiusI == 0) {
+                logger.warning(format(" Atom %d element not determined.", i + 1))
+                return
+            }
+            double[] xyz = [atom1.getX(), atom1.getY(), atom1.getZ()]
+            for (int j = 0; j < atoms.size(); j++) {
+                if (i == j) {
+                    continue
+                }
+                Atom atom2 = atoms[j]
+                String atomJelement = getAtomElement(atom2)
+                double radiusJ = getCovalentRadius(atomJelement)
+                if (radiusJ == 0) {
+                    logger.warning(format(" Atom %d element not determined.", j + 1))
+                    return
+                }
+                double[] xyz2 = [atom2.getX(), atom2.getY(), atom2.getZ()]
+                double length = dist(xyz, xyz2)
+                double bondLength = radiusI + radiusJ + BOND_TOLERANCE
+                if (length < bondLength) {
+                    Bond bond = new Bond(atom1, atom2)
+                    atom1.setBond(bond)
+                    atom2.setBond(bond)
+                }
+            }
+        }
+    }
 
-  @Override
-  List<Potential> getPotentials() {
-    return new ArrayList<Potential>()
-  }
+    /**
+     * Parse atom name to determine atomic element.
+     *
+     * @param atom Atom whose element we desire
+     * @return String specifying atom element.
+     */
+    private static String getAtomElement(Atom atom){
+        return atom.getName().replaceAll("_", "").replaceAll("-", "").replaceAll(" +","").split("[0-9]")[0]
+    }
+
+    /**
+     * Finds all atoms that are bonded to one another.
+     * See potential/Utilities/collectAtoms
+     *
+     * @param seed Starting atom.
+     * @param atoms that are bonded.
+     */
+    private static void collectAtoms(Atom seed, List<Atom> atoms) {
+        if (seed == null) {
+            return
+        }
+        atoms.add(seed)
+        for (Bond b : seed.getBonds()) {
+            Atom nextAtom = b.get1_2(seed)
+            if (!atoms.contains(nextAtom)) {
+                collectAtoms(nextAtom, atoms)
+            }
+        }
+    }
+    @Override
+    List<Potential> getPotentials() {
+        return new ArrayList<Potential>()
+    }
 }

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/SaveAsPDB.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/SaveAsPDB.groovy
@@ -186,9 +186,9 @@ class SaveAsPDB extends PotentialScript {
     if (openFilter != null && (openFilter instanceof XYZFilter || openFilter instanceof PDBFilter)
         && numModels > 1) {
       saveFilter.setModelNumbering(1)
+      saveFile.append("ENDMDL\n")
       try {
         while (openFilter.readNext(false)) {
-          saveFile.append("ENDMDL\n")
           saveOptions.preSaveOperations(activeAssembly)
           saveFilter.writeFile(saveFile, true, true, false)
         }

--- a/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
@@ -1388,7 +1388,6 @@ public final class PDBFilter extends SystemFilter {
     if (pdbAtoms != activeMolecularAssembly.getAtomArray().length) {
       numberAtoms(activeMolecularAssembly);
     }
-
     return true;
   }
 
@@ -1746,9 +1745,11 @@ public final class PDBFilter extends SystemFilter {
       model.append(repeat(" ", 65));
     }
     activeMolecularAssembly.setFile(newFile);
-    activeMolecularAssembly.setName(newFile.getName());
+    if(activeMolecularAssembly.getName() == null){
+      activeMolecularAssembly.setName(newFile.getName());
+    }
     if (logWrites) {
-      logger.log(Level.INFO, " Saving {0}", activeMolecularAssembly.getName());
+      logger.log(Level.INFO, " Saving {0}", newFile.getName());
     }
 
     try (FileWriter fw = new FileWriter(newFile, append); BufferedWriter bw = new BufferedWriter(

--- a/modules/potential/src/main/java/ffx/potential/parsers/XYZFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/XYZFilter.java
@@ -629,14 +629,16 @@ public class XYZFilter extends SystemFilter {
       newFile = version(saveFile);
     }
     activeMolecularAssembly.setFile(newFile);
-    activeMolecularAssembly.setName(newFile.getName());
+    if(activeMolecularAssembly.getName() == null){
+      activeMolecularAssembly.setName(newFile.getName());
+    }
 
     try (FileWriter fw = new FileWriter(newFile, append && newFile.exists());
         BufferedWriter bw = new BufferedWriter(fw)) {
       // XYZ File First Line
       int numberOfAtoms = activeMolecularAssembly.getAtomList().size();
       StringBuilder sb =
-          new StringBuilder(format("%7d  %s", numberOfAtoms, activeMolecularAssembly.toString()));
+          new StringBuilder(format("%7d  %s", numberOfAtoms, activeMolecularAssembly.getName()));
       if (extraLines != null) {
         for (String line : extraLines) {
           line = line.replaceAll("\n", " ");

--- a/modules/potential/src/main/java/ffx/potential/utils/ProgressiveAlignmentOfCrystals.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ProgressiveAlignmentOfCrystals.java
@@ -47,9 +47,6 @@ import static ffx.potential.utils.Superpose.calculateTranslation;
 import static ffx.potential.utils.Superpose.rmsd;
 import static ffx.potential.utils.Superpose.rotate;
 import static ffx.potential.utils.Superpose.translate;
-import static ffx.potential.parsers.SystemFilter.setVersioning;
-import static ffx.potential.parsers.SystemFilter.Versioning.PREFIX;
-import static ffx.potential.parsers.SystemFilter.version;
 import static java.lang.String.format;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.fill;
@@ -201,7 +198,6 @@ public class ProgressiveAlignmentOfCrystals {
    */
   public ProgressiveAlignmentOfCrystals(SystemFilter baseFilter,
       SystemFilter targetFilter, boolean isSymmetric) {
-    setVersioning(PREFIX);
     this.baseFilter = baseFilter;
     this.targetFilter = targetFilter;
     this.isSymmetric = isSymmetric;
@@ -284,6 +280,7 @@ public class ProgressiveAlignmentOfCrystals {
    * @param zPrime2 Number of asymmetric units in second crystal.
    * @param alphaCarbons Perform comparisons on only alpha carbons.
    * @param noHydrogen Perform comparisons without hydrogen atoms.
+   * @param symCheck Only use unique atom environments (prevents mislabeled symmetries).
    * @param exhaustive Perform exhaustive number of comparisons (takes longer, but more information
    *     returned).
    * @param save Save out PDBs of the resulting superposition.
@@ -294,7 +291,7 @@ public class ProgressiveAlignmentOfCrystals {
    * @return RunningStatistics Statistics for comparisons performed.
    */
   public RunningStatistics comparisons(int nAU, int inflatedAU, int numSearch, int numSearch2,
-      int zPrime, int zPrime2, boolean alphaCarbons, boolean noHydrogen, boolean exhaustive, boolean save, boolean restart,
+      int zPrime, int zPrime2, boolean alphaCarbons, boolean noHydrogen, boolean symCheck, boolean exhaustive, boolean save, boolean restart,
       boolean write, boolean machineLearning, String pacFileName) {
 
     RunningStatistics runningStatistics;
@@ -364,6 +361,15 @@ public class ProgressiveAlignmentOfCrystals {
       return null;
     }
 
+    if(symCheck){
+      // Remove atoms that are at non-unique positions (Might be mislabeled).
+      environmentCheck(baseAssembly, atomList);
+      if(atomList.size() < 1){
+        logger.info("\n Symmetry check removed remaining atoms from first crystal. Rerun without \"symCheck\".");
+        return null;
+      }
+    }
+
     // Atom arrays from the 2nd assembly.
     MolecularAssembly targetAssembly = targetFilter.getActiveMolecularSystem();
     Atom[] targetAtoms = targetAssembly.getAtomArray();
@@ -393,6 +399,16 @@ public class ProgressiveAlignmentOfCrystals {
       logger.info("\n No atoms were selected for the PAC RMSD in second crystal.");
       return null;
     }
+
+
+    if(symCheck){
+      // Remove atoms that are at non-unique positions (Might be mislabeled).
+      environmentCheck(targetAssembly, atomList2);
+      if(atomList2.size() < 1){
+        logger.warning("\n Symmetry check removed remaining atoms from second crystal. Rerun without \"symCheck\".");
+        return null;
+      }
+    }
     int[] comparisonAtoms = atomList.stream().mapToInt(i->i).toArray();
     int[] comparisonAtoms2 = atomList2.stream().mapToInt(i->i).toArray();
 
@@ -411,7 +427,7 @@ public class ProgressiveAlignmentOfCrystals {
     }
 
     if(compareAtomsSize != compareAtomsSize2){
-      logger.warning("Selected atom sizes differ between crystals.");
+      logger.warning(" Selected atom sizes differ between crystals.");
     }
 
     // Number of atoms included in the PAC RMSD.
@@ -650,7 +666,7 @@ public class ProgressiveAlignmentOfCrystals {
     baseindices.add(0);
     basediff.add(rmsd(tempBase, tempBase, mass));
     base0XYZ.add(tempBase);
-    int baseSearchValue = (baseXtal.spaceGroup.respectsChirality()) ? zPrime : 2 * zPrime;
+    int baseSearchValue = (baseXtal.spaceGroup.respectsChirality()) ? zPrime * numSearch: 2 * zPrime * numSearch;
     // Start from 1 as zero is automatically added.
     int index = 1;
 
@@ -685,16 +701,16 @@ public class ProgressiveAlignmentOfCrystals {
       logger.finer(format(" %d conformations detected out of %d in base crystal.", baseIndices.length, baseSearchValue * numSearch));
       logger.finer(" Target Search Conformations:");
     }
-    int targetSearchValue = (targetXtal.spaceGroup.respectsChirality()) ? zPrime2 : 2 * zPrime2;
+    int targetSearchValue = (targetXtal.spaceGroup.respectsChirality()) ? zPrime2 * numSearch2 : 2 * zPrime2 * numSearch2;
 
     ArrayList<double[]> target0XYZ = new ArrayList<>();
     List<Integer> targetindices = new ArrayList<>();
     List<Integer> targetBaseindices = new ArrayList<>();
     List<Double> targetdiff = new ArrayList<>();
-    // Determine number of conformation in second.
+    // Determine number of conformations in second.
     index = 0;
-    // TODO: change below to while(targetDiff.size() < targetSearchValue) when convinced
-    numConfCheck = (exhaustive)? nTargetMols : targetSearchValue;
+    // TODO: change below to while(baseDiff.size() < baseSearchValue) when convinced
+    numConfCheck = (exhaustive) ? nTargetMols : targetSearchValue;
     while (targetdiff.size() < numConfCheck) {
       double[] targetCheckMol = new double[nCoords];
       arraycopy(targetXYZOrig, molDist2[index].getIndex() * nCoords, targetCheckMol, 0, nCoords);
@@ -720,7 +736,7 @@ public class ProgressiveAlignmentOfCrystals {
         target0XYZ.add(targetCheckMol);
       }
       index++;
-      if (index >= molDist2.length) {
+      if(index>=molDist2.length){
         break;
       }
     }
@@ -742,6 +758,8 @@ public class ProgressiveAlignmentOfCrystals {
         logger.finer(format(" %d %4.4f %d", i, targetDiff[i], targetBaseIndices[i]));
       }
     }
+
+    
 
     // Coordinate arrays to save out structures at the end.
     double[] n1TargetNMols = new double[nAU * nCoords];
@@ -1427,6 +1445,134 @@ public class ProgressiveAlignmentOfCrystals {
   }
 
   /**
+   * Check to see if atoms have unique bonded environment (helps with mislabeled atoms).
+   * @param assembly Assembly containing asymmetric unit.
+   * @param indices Current indices of active atoms.
+   */
+  private static void environmentCheck(MolecularAssembly assembly, ArrayList<Integer> indices) {
+    List<Atom> atomList = assembly.getAtomList();
+    ArrayList<Integer> copy = new ArrayList<>(indices);
+    for (int j = 0; j < copy.size(); j++) {
+      for (int k = j; k < copy.size(); k++) {
+        Atom a1 = atomList.get(copy.get(j));
+        Atom a2 = atomList.get(copy.get(k));
+        if (a1.getIndex() != a2.getIndex()) {
+          AtomEnvironmentComparator ac = new AtomEnvironmentComparator();
+          int value = ac.compare(a1, a2);
+          if (value == 0) {
+            indices.remove(copy.get(j));
+            indices.remove(copy.get(k));
+            logger.finer(" Removed identical environments " + a1 + " and " + a2);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Class to determine the bonded environment of atoms.
+   */
+  static class AtomEnvironmentComparator implements Comparator<Object>{
+    /**
+     * Comparison method of the bonded environment of two atoms.
+     * @param obj1 Atom 1 to compare.
+     * @param obj2 Atom 2 to compare.
+     * @return -1 if reverse order, 1 if same order, or 0 unsuccessful.
+     */
+    @Override
+    public int compare(Object obj1, Object obj2){
+      Atom a1 = (Atom) obj1;
+      Atom a2 = (Atom) obj2;
+      int comp = Integer.compare(a1.getMoleculeNumber(), a2.getMoleculeNumber());
+      if(comp==0){
+        comp = Integer.compare(a1.getResidueNumber(), a2.getResidueNumber());
+      }
+      if(comp==0){
+        comp = -Double.compare(a1.getMass(), a2.getMass());
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.getBonds().size(), a2.getBonds().size());
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get12List().size(), a2.get12List().size());
+      }
+      if(comp==0){
+        for(int i = 0; i< a1.get12List().size(); i++){
+          Atom a12 = a1.get12List().get(i);
+          Atom a22 = a2.get12List().get(i);
+          comp = shallowCompare(a12, a22);
+          if(comp != 0){
+            break;
+          }
+        }
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get13List().size(), a2.get13List().size());
+      }
+      if(comp==0){
+        for(int i = 0; i< a1.get13List().size(); i++){
+          Atom a12 = a1.get13List().get(i);
+          Atom a22 = a2.get13List().get(i);
+          comp = shallowCompare(a12, a22);
+          if(comp != 0){
+            break;
+          }
+        }
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get14List().size(), a2.get14List().size());
+      }
+      if(comp==0){
+        for(int i = 0; i< a1.get14List().size(); i++){
+          Atom a12 = a1.get14List().get(i);
+          Atom a22 = a2.get14List().get(i);
+          comp = shallowCompare(a12, a22);
+          if(comp != 0){
+            break;
+          }
+        }
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get15List().size(), a2.get15List().size());
+      }
+      if(comp==0){
+        for(int i = 0; i< a1.get15List().size(); i++){
+          Atom a12 = a1.get15List().get(i);
+          Atom a22 = a2.get15List().get(i);
+            comp = shallowCompare(a12, a22);
+          if(comp != 0){
+            break;
+          }
+        }
+      }
+      return comp;
+    }
+
+    /**
+     * Comparison of atoms to see if they have the same number of bonds.
+     * @param a1 Atom 1 to compare.
+     * @param a2 Arom 2 to compare.
+     * @return -1 if reverse order, 1 if same order, or 0 unsuccessful.
+     */
+    private int shallowCompare(Atom a1, Atom a2){
+      int comp = Integer.compare(a1.getBonds().size(), a2.getBonds().size());
+      if(comp==0){
+        comp = Integer.compare(a1.get12List().size(), a2.get12List().size());
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get13List().size(), a2.get13List().size());
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get14List().size(), a2.get14List().size());
+      }
+      if(comp==0){
+        comp = Integer.compare(a1.get15List().size(), a2.get15List().size());
+      }
+      return comp;
+    }
+  }
+
+  /**
    * Generate and expanded sphere of asymetric unit with the intention of observing a crystals
    * distribution of replicates rather to facilitate comparisons that go beyond lattice parameters.
    *
@@ -1759,7 +1905,7 @@ public class ProgressiveAlignmentOfCrystals {
   private static void saveAssemblyPDB(MolecularAssembly molecularAssembly, double[] coords,
       int[] comparisonAtoms, String description) {
     String fileName = FilenameUtils.removeExtension(molecularAssembly.getName());
-    File saveLocationPDB = version(new File(fileName + description + ".pdb"));
+    File saveLocationPDB = PDBFilter.version(new File(fileName + description + ".pdb"));
     // Save aperiodic system of n_mol closest atoms for visualization
     MolecularAssembly currentAssembly = new MolecularAssembly(molecularAssembly.getName());
     ArrayList<Atom> newAtomList = new ArrayList<>();
@@ -1820,7 +1966,8 @@ public class ProgressiveAlignmentOfCrystals {
     saveAssemblyPDB(molecularAssembly, coords, comparisonAtoms, description);
     String fileName = FilenameUtils.removeExtension(molecularAssembly.getName());
     try {
-      File csv = version(new File(fileName + description + ".csv"));
+      // Needs same name as PDB so follow PDB format.
+      File csv = PDBFilter.version(new File(fileName + description + ".csv"));
       if (csv.createNewFile()) {
         BufferedWriter bw = new BufferedWriter(new FileWriter(csv, false));
         bw.append("rms\n");


### PR DESCRIPTION
**CIFtoXYZ:** Added functionality for Z' > 1 crystals. Added a flag that attempts to fix lattice parameters that do not agree with the current lattice system (--fl) instead of ending conversion with an error. Fixed a bug that prevented the space group name between structures in concatenated CIF files to be updated with each structure.

**SuperposeCrystals/ProgressiveAlignmentofCrystals:** Added a flag for preliminary functionality of a bonded environment check (--sc). Atoms within a species that have the same atom type, number of 1-2, 1-3, 1-4, and 1-5 bonds are considered to have identical environments and are excluded when this flag is activated. This helps prevent atom numbering/ring flipping from having a poor effect on outcome RMSD. I have only tested this flag on compound XXIII.

**XYZFilter/PDBFilter**: Structure names now check to see if the molecular assembly has a name before defaulting to the previous behavior of the file name. This facilitates finding specific structures within an archive or concatenated PDB.

Various comment updates and refactoring in the crystal package.
