### PR TITLE
PAC and CIF conversion updates

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -89,20 +89,6 @@ class SuperposeCrystals extends AlgorithmsScript {
   private int numInflatedAU
 
   /**
-   * --ns or --numSearch Crystal 1 AUs to compare for unique conformations.
-   */
-  @Option(names = ['--ns', '--numSearch'], paramLabel = '1', defaultValue = '1',
-      description = 'Crystal 1 AUs to compare for unique conformations.')
-  private int numSearch
-
-  /**
-   * --ns2 or --numSearch2 Crystal 2 AUs to compare for unique conformations.
-   */
-  @Option(names = ['--ns2', '--numSearch2'], paramLabel = '1', defaultValue = '1',
-      description = 'Crystal 2 AUs to compare for unique conformations.')
-  private int numSearch2
-
-  /**
    * --zp or --zPrime Z' for crystal 1 (-1 to autodetect).
    */
   @Option(names = ['--zp', '--zPrime'], paramLabel = '-1', defaultValue = '-1',
@@ -115,6 +101,13 @@ class SuperposeCrystals extends AlgorithmsScript {
   @Option(names = ['--zp2', '--zPrime2'], paramLabel = '-1', defaultValue = '-1',
       description = "Z'' for crystal 2 (-1 to autodetect).")
   private int zPrime2
+
+  /**
+   * --mt or --moleculeTolerance Tolerance to determine if two molecules are different.
+   */
+  @Option(names = ['--mt', '--moleculeTolerance'], paramLabel = '0.1', defaultValue = '0.1',
+          description = "Tolerance to determine if two molecules are different.")
+  private double molTol
 
   /**
    * -w or --write Write out the PAC RMSD matrix.
@@ -178,20 +171,6 @@ class SuperposeCrystals extends AlgorithmsScript {
   @Option(names = ['-l', '--linkage'], paramLabel = '0', defaultValue = '0',
       description = 'Single (0), Average (1), or Complete (2) coordinate linkage for molecule prioritization.')
   private int linkage
-
-  /**
-   * --fo or --fileOrder Prioritize matching molecules of the first command line crystal (rather than using a density criteria).
-   */
-  @Option(names = ['--fo', '--fileOrder'], paramLabel = "false", defaultValue = "false",
-      description = 'Prioritize matching molecules of the first command line crystal (rather than using a density criteria).')
-  private static boolean fileOrder
-
-  /**
-   * --ld or --lowDensity Prioritize matching molecules of the lower density crystal (default uses higher density).
-   */
-  @Option(names = ['--ld', '--lowDensity'], paramLabel = "false", defaultValue = "false",
-      description = 'Prioritize matching molecules of the lower density crystal (default uses higher density).')
-  private static boolean lowDensity
 
   /**
    * --pc or --prioritizeCrystals Prioritize the crystals being compared based on high density (0), low density (1), or file order (2).
@@ -305,7 +284,7 @@ class SuperposeCrystals extends AlgorithmsScript {
     }
 
     runningStatistics =
-        pac.comparisons(numAU, numInflatedAU, numSearch, numSearch2, zPrime, zPrime2, alphaCarbons,
+        pac.comparisons(numAU, numInflatedAU, molTol, zPrime, zPrime2, alphaCarbons,
             noHydrogen, massWeighted, crystalPriority, exhaustive, savePDB,
             restart, write,
             machineLearning, linkage, pacFilename)

--- a/modules/crystal/src/main/java/ffx/crystal/Crystal.java
+++ b/modules/crystal/src/main/java/ffx/crystal/Crystal.java
@@ -217,7 +217,7 @@ public class Crystal {
       sb.append(format("  Gamma:                               %18.15e\n", gamma));
       if(tempLS == LatticeSystem.HEXAGONAL_LATTICE || tempLS == LatticeSystem.RHOMBOHEDRAL_LATTICE) {
         // Try to convert between hexagonal and rhombohedral lattices to fix crystal.
-        Crystal convertedCrystal = SpaceGroupConversions.hrConversion(this, sg);
+        Crystal convertedCrystal = SpaceGroupConversions.hrConversion(a, b, c, alpha, beta, gamma, tempSG);
         this.a = convertedCrystal.a;
         this.b = convertedCrystal.b;
         this.c = convertedCrystal.c;

--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroupConversions.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroupConversions.java
@@ -60,16 +60,29 @@ public class SpaceGroupConversions {
    * Convert between hexagonal and rhombohedral space groups.
    *
    * @param crystal Crystal parameters to be converted.
-   * @param spaceGroup Current space group name.
    * @return Converted crystal.
    */
-  public static Crystal hrConversion(Crystal crystal, String spaceGroup) {
+  public static Crystal hrConversion(Crystal crystal) {
+    return hrConversion(crystal.a, crystal.b, crystal.c, crystal.alpha, crystal.beta, crystal.gamma, crystal.spaceGroup);
+  }
+
+  /**
+   * Convert between hexagonal and rhombohedral space groups.
+   * @param a proposed axis length
+   * @param b proposed axis length
+   * @param c proposed axis length
+   * @param alpha proposed angle
+   * @param beta proposed angle
+   * @param gamma proposed angle
+   * @param currentSG Space group to be converted
+   * @return Converted crystal satisfying other lattice system.
+   */
+  public static Crystal hrConversion(double a, double b, double c, double alpha, double beta, double gamma, SpaceGroup currentSG) {
     //Name for converted space group.
     String xtalName = "";
     // Going from hexagonal to rhombohedral (true), or visa versa (false).
     boolean hexStart = false;
     // Determine starting space group.
-    SpaceGroup currentSG = SpaceGroupDefinitions.spaceGroupFactory(spaceGroup);
     switch (currentSG.shortName) {
       case ("H3"):
         logger.info(" Converting from H3 to R3:");
@@ -136,37 +149,31 @@ public class SpaceGroupConversions {
         break;
       default:
         logger.severe(format(" Unable to determine converted version for space group: %s",
-            spaceGroup));
-        return crystal;
+            currentSG));
+        return new Crystal(a, b, c, alpha, beta, gamma, currentSG.shortName);
     }
 
     // Hexagonal and Rhombohedral space groups are frequently treated synonymously, therefore check if mislabeled.
-    double aCurrent = crystal.a;
-    double bCurrent = crystal.b;
-    double cCurrent = crystal.c;
-    double alphaCurrent = crystal.alpha;
-    double betaCurrent = crystal.beta;
-    double gammaCurrent = crystal.gamma;
     if (hexStart) {
       //Hexagonal aH = bH, alpha = beta = 90 gamma = 120
-      if(LatticeSystem.RHOMBOHEDRAL_LATTICE.validParameters(aCurrent, bCurrent, cCurrent, alphaCurrent, betaCurrent, gammaCurrent)){
+      if(LatticeSystem.RHOMBOHEDRAL_LATTICE.validParameters(a, b, c, alpha, beta, gamma)){
         logger.info(" Crystal already has valid lattice parameters for new space group " + xtalName);
-        return new Crystal(aCurrent, bCurrent, cCurrent, alphaCurrent, betaCurrent, gammaCurrent, xtalName);
+        return new Crystal(a, b, c, alpha, beta, gamma, xtalName);
       }
 
-      double aR = sqrt(1.0 / 9.0 * (pow(cCurrent, 2) + 3 * pow(aCurrent, 2)));
-      double aRAlpha = acos((2 * pow(cCurrent, 2) - 3 * pow(aCurrent, 2)) /
-          (2 * pow(cCurrent, 2) + 6 * pow(aCurrent, 2))) / PI * 180;
+      double aR = sqrt(1.0 / 9.0 * (pow(c, 2) + 3 * pow(a, 2)));
+      double aRAlpha = acos((2 * pow(c, 2) - 3 * pow(a, 2)) /
+          (2 * pow(c, 2) + 6 * pow(a, 2))) / PI * 180;
 
       return new Crystal(aR, aR, aR, aRAlpha, aRAlpha, aRAlpha, xtalName);
     } else {
-      if(LatticeSystem.HEXAGONAL_LATTICE.validParameters(aCurrent, bCurrent, cCurrent, alphaCurrent, betaCurrent, gammaCurrent)){
+      if(LatticeSystem.HEXAGONAL_LATTICE.validParameters(a, b, c, alpha, beta, gamma)){
         logger.info(" Crystal already has valid lattice parameters for new space group " + xtalName);
-        return new Crystal(aCurrent, bCurrent, cCurrent, alphaCurrent, betaCurrent, gammaCurrent, xtalName);
+        return new Crystal(a, b, c, alpha, beta, gamma, xtalName);
       }
 
-      double aH = 2 * pow(aCurrent, 2) * (1 - cos(alphaCurrent / 180 * PI));
-      double cH = sqrt(3 * pow(aCurrent, 2) * (1 + 2 * cos(alphaCurrent / 180 * PI)));
+      double aH = 2 * pow(a, 2) * (1 - cos(alpha / 180 * PI));
+      double cH = sqrt(3 * pow(a, 2) * (1 + 2 * cos(alpha / 180 * PI)));
 
       return new Crystal(aH, aH, cH, 90.00, 90.00, 120.00, xtalName);
     }

--- a/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SpaceGroupDefinitions.java
@@ -8145,7 +8145,7 @@ public class SpaceGroupDefinitions {
     for (int i = 0; i < num; i++) {
       String s1 = SpaceGroupInfo.spaceGroupNames[i];
       String s2 = SpaceGroupInfo.pdbSpaceGroupNames[i];
-      if (s1.equalsIgnoreCase(n) || s2.equalsIgnoreCase(n)) {
+      if (s1.equalsIgnoreCase(n.replaceAll(" +","")) || s2.equalsIgnoreCase(n)) {
         return i + 1;
       }
     }

--- a/modules/potential/src/main/java/ffx/potential/utils/ProgressiveAlignmentOfCrystals.java
+++ b/modules/potential/src/main/java/ffx/potential/utils/ProgressiveAlignmentOfCrystals.java
@@ -73,8 +73,6 @@ import ffx.utilities.DoubleIndexPair;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -185,7 +183,7 @@ public class ProgressiveAlignmentOfCrystals {
     /**
      * Specify the number of digits to round intermediate comparisons.
      */
-    private static final int ROUND_PLACES = 10;
+    private static final int ROUND_PLACES = 14;
     /**
      * If molecules between two crystals differ below this tolerance, it is assumed they are equivalent.
      */
@@ -276,8 +274,6 @@ public class ProgressiveAlignmentOfCrystals {
      *
      * @param nAU              Number of asymmetric units to compare.
      * @param inflatedAU       Minimum number of asymmetric units in inflated crystal
-     * @param numSearch        Number of loops to search for stereoisomers in first system.
-     * @param numSearch2       Number of loops to search for stereoisomers in second system.
      * @param zPrime           Number of asymmetric units in first crystal.
      * @param zPrime2          Number of asymmetric units in second crystal.
      * @param alphaCarbons     Perform comparisons on only alpha carbons.
@@ -291,7 +287,7 @@ public class ProgressiveAlignmentOfCrystals {
      * @param pacFileName      The filename to use.
      * @return RunningStatistics Statistics for comparisons performed.
      */
-    public RunningStatistics comparisons(int nAU, int inflatedAU, int numSearch, int numSearch2, int zPrime, int zPrime2,
+    public RunningStatistics comparisons(int nAU, int inflatedAU, double molTol, int zPrime, int zPrime2,
                                          boolean alphaCarbons, boolean noHydrogen, boolean massWeighted, int crystalPriority,
                                          boolean exhaustive, boolean save, boolean restart, boolean write,
                                          boolean machineLearning, int linkage, String pacFileName) {
@@ -311,16 +307,7 @@ public class ProgressiveAlignmentOfCrystals {
             }
         }
 
-        // If Sohncke group must respect chirality (assuming mono-isomer AU) so numSearch = 1
         MolecularAssembly baseAssembly = baseFilter.getActiveMolecularSystem();
-        Crystal baseCrystal = baseAssembly.getCrystal().getUnitCell();
-        if (!exhaustive && baseCrystal.spaceGroup.respectsChirality() && zPrime < 2) {
-            numSearch = 1;
-        }
-        Crystal targetCrystal = targetFilter.getActiveMolecularSystem().getCrystal().getUnitCell();
-        if (!exhaustive && targetCrystal.spaceGroup.respectsChirality() && zPrime2 < 2) {
-            numSearch2 = 1;
-        }
 
         // Minimum amount of time for a single comparison.
         double minTime = Double.MAX_VALUE;
@@ -388,6 +375,8 @@ public class ProgressiveAlignmentOfCrystals {
         // Label for logging.
         rmsdLabel = format("RMSD_%d", nAU);
 
+        Crystal baseCrystal = baseAssembly.getCrystal().getUnitCell();
+        Crystal targetCrystal = targetFilter.getActiveMolecularSystem().getCrystal().getUnitCell();
         // Loop over conformations in the base assembly.
         for (int row = restartRow; row < baseSize; row++) {
             // Initialize the distance this rank is responsible for to zero.
@@ -425,8 +414,9 @@ public class ProgressiveAlignmentOfCrystals {
                                 row + 1, baseCrystal.toShortString(), baseLabel,
                                 column + 1, targetCrystal.toShortString(), targetLabel));
                         // Compute the PAC RMSD.
-                        rmsd = compare(comparisonAtoms, comparisonAtoms2, compareAtomsSize, compareAtomsSize2, nAU, inflatedAU,
-                                numSearch, numSearch2, z1, z2, row * targetSize + column, massWeighted, crystalPriority, exhaustive, save, machineLearning, linkage);
+                        rmsd = compare(comparisonAtoms, comparisonAtoms2, compareAtomsSize, compareAtomsSize2, nAU,
+                                inflatedAU, molTol, z1, z2, row * targetSize + column, massWeighted,
+                                crystalPriority, exhaustive, save, machineLearning, linkage);
                         time += System.nanoTime();
                         double timeSec = time * 1.0e-9;
                         // Record the fastest comparison.
@@ -487,26 +477,24 @@ public class ProgressiveAlignmentOfCrystals {
      * @param compareAtomsSize2     Number of active atoms in asymmetric unit of second crystal.
      * @param nAU                   Number of asymmetric units to compare.
      * @param inflatedAU            Number of asymmetric units in expanded system.
-     * @param numSearch             Number of molecules to check for conformations in the first system.
-     * @param numSearch2            Number of molecules to check for conformations in the second system.
      * @param exhaustive            Perform exhaustive number of comparisons.
      * @param save                  Save out PDBs of compared crystals.
      * @param machineLearning       Save out PDBs and CSVs of compared crystals.
      * @return the computed RMSD.
      */
     private double compare(int[] comparisonAtomsStart, int[] comparisonAtoms2Start, int compareAtomsSize,
-                           int compareAtomsSize2, int nAU, int inflatedAU, int numSearch, int numSearch2, int zPrime, int zPrime2,
-                           int compNum, boolean massWeighted, int crystalPriority, boolean exhaustive, boolean save, boolean machineLearning, int linkage) {
+                           int compareAtomsSize2, int nAU, int inflatedAU, double molTol,
+                           int zPrime, int zPrime2, int compNum, boolean massWeighted, int crystalPriority,
+                           boolean exhaustive, boolean save, boolean machineLearning, int linkage) {
         // TODO: Does PAC work for a combination of molecules and polymers?
 
-        //Remove atoms not used in comparisons from the original molecular assembly (crystal 1).
+        // Prioritize crystal order based on user specification (High/low density or file order).
         MolecularAssembly bAssembly = baseFilter.getActiveMolecularSystem();
         double baseDensity = bAssembly.getCrystal().getDensity(bAssembly.getMass());
         MolecularAssembly tAssembly = targetFilter.getActiveMolecularSystem();
         double targetDensity = tAssembly.getCrystal().getDensity(tAssembly.getMass());
         logger.finer(format(" Base Density: %4.4f Target Density: %4.4f", baseDensity, targetDensity));
         boolean densityCheck = (crystalPriority==1) ? baseDensity < targetDensity : baseDensity > targetDensity;
-
         MolecularAssembly staticAssembly;
         MolecularAssembly mobileAssembly;
         if (densityCheck || crystalPriority==2) {
@@ -521,14 +509,12 @@ public class ProgressiveAlignmentOfCrystals {
             int temp = compareAtomsSize;
             compareAtomsSize = compareAtomsSize2;
             compareAtomsSize2 = temp;
-            temp = numSearch;
-            numSearch = numSearch2;
-            numSearch2 = temp;
             temp = zPrime;
             zPrime = zPrime2;
             zPrime2 = temp;
         }
 
+        //Remove atoms not used in comparisons from the original molecular assembly (crystal 1).
         staticAssembly.moveAllIntoUnitCell();
         double[] massStart = new double[comparisonAtomsStart.length];
         double[] reducedBaseCoords = reduceSystem(staticAssembly, comparisonAtomsStart, massStart, massWeighted);
@@ -544,6 +530,7 @@ public class ProgressiveAlignmentOfCrystals {
         double[] targetXYZOrig = generateInflatedSphere(targetXtal, reducedTargetCoords, massStart2,
                 inflatedAU);
 
+        // Check masses are same for both AUs (atom order check).
         double[] mass = new double[compareAtomsSize];
         double[] massTemp = new double[compareAtomsSize2];
         arraycopy(massStart, 0, mass, 0, compareAtomsSize);
@@ -558,12 +545,14 @@ public class ProgressiveAlignmentOfCrystals {
             logger.warning(" Atom masses are not equivalent between crystals.\n " +
                     "Ensure atom ordering is same in both inputs.");
         }
+
         // Remove duplicated atoms from Z' > 1.
         int[] comparisonAtoms = new int[compareAtomsSize];
         arraycopy(comparisonAtomsStart, 0, comparisonAtoms, 0, compareAtomsSize);
         int[] comparisonAtoms2 = new int[compareAtomsSize2];
         arraycopy(comparisonAtoms2Start, 0, comparisonAtoms2, 0, compareAtomsSize2);
 
+        // Check atom comparison selections match between both systems.
         if (!Arrays.equals(comparisonAtoms, comparisonAtoms2)) {
             if (logger.isLoggable(Level.FINER)) {
                 for (int i = 0; i < compareAtomsSize; i++) {
@@ -641,107 +630,53 @@ public class ProgressiveAlignmentOfCrystals {
             }
         }
 
-        //  Frank-Kasper phases of metallic ions can reach a coordination number of 16...
         //Determine if AUs in first system are same hand as center most in first (stereoisomer handling).
-        logger.finer(" Base Search Conformations:");
+        logger.finer(" Search Conformations of Base Crystal:");
+        int baseSearchValue = (baseXtal.spaceGroup.respectsChirality()) ? zPrime : 2 * zPrime;
         ArrayList<double[]> base0XYZ = new ArrayList<>();
-        double[] tempBase = new double[nCoords];
-        arraycopy(baseXYZOrig, molDist1[0].getIndex() * nCoords, tempBase, 0, nCoords);
         List<Integer> baseindices = new ArrayList<>();
-        List<Double> basediff = new ArrayList<>();
-        baseindices.add(0);
-        basediff.add(rmsd(tempBase, tempBase, mass));
-        base0XYZ.add(tempBase);
-        int baseSearchValue = (baseXtal.spaceGroup.respectsChirality()) ? zPrime * numSearch : 2 * zPrime * numSearch;
-        // Start from 1 as zero is automatically added.
-        int index = 1;
-
-        //Determine number of conformations in first crystal
-        // TODO: change below to while(baseDiff.size() < baseSearchValue) when convinced
-        int numConfCheck = (exhaustive || numSearch > 1) ? nBaseMols : baseSearchValue;
-        while (basediff.size() < numConfCheck) {
-            double[] baseCheckMol = new double[nCoords];
-            arraycopy(baseXYZOrig, molDist1[index].getIndex() * nCoords, baseCheckMol, 0,
-                    nCoords);
-            double value = doMoleculesMatch(base0XYZ.get(0), baseCheckMol, mass);
-            value = roundToPlaces(value);
-            if (addLooseUnequal(basediff, value)) {
-                baseindices.add(index);
-                base0XYZ.add(baseCheckMol);
-            } else if (Collections.frequency(basediff, value) < numSearch) {
-                basediff.add(value);
-                baseindices.add(index);
-                base0XYZ.add(baseCheckMol);
-            }
-            index++;
-            if (index >= molDist1.length) {
-                break;
-            }
-        }
-        double[] baseDiff = basediff.stream().mapToDouble(i -> i).toArray();
+        numberUniqueAUs(baseXYZOrig, molDist1, base0XYZ, baseindices, nCoords, baseSearchValue, exhaustive,
+                nBaseMols, mass, molTol);
         double[][] baseXYZs = new double[base0XYZ.size()][nCoords];
         base0XYZ.toArray(baseXYZs);
         Integer[] baseIndices = new Integer[baseindices.size()];
         baseindices.toArray(baseIndices);
-        if (logger.isLoggable(Level.FINER)) {
-            logger.finer(format(" %d conformations detected out of %d in base crystal.", baseIndices.length, baseSearchValue * numSearch));
-            logger.finer(" Target Search Conformations:");
-        }
-        int targetSearchValue = (targetXtal.spaceGroup.respectsChirality()) ? zPrime2 * numSearch2 : 2 * zPrime2 * numSearch2;
+        logger.finer(format(" %d conformations detected out of %d in base crystal.", baseIndices.length, baseSearchValue));
 
+        logger.finer(" Search Conformations of Target Crystal:");
+        int targetSearchValue = (targetXtal.spaceGroup.respectsChirality()) ? zPrime2 : 2 * zPrime2;
         ArrayList<double[]> target0XYZ = new ArrayList<>();
         List<Integer> targetindices = new ArrayList<>();
-        List<Integer> targetBaseindices = new ArrayList<>();
-        List<Double> targetdiff = new ArrayList<>();
-        // Determine number of conformations in second.
-        index = 0;
-        // TODO: change below to while(baseDiff.size() < baseSearchValue) when convinced
-        numConfCheck = (exhaustive || numSearch2 > 1) ? nTargetMols : targetSearchValue;
-        while (targetdiff.size() < numConfCheck) {
-            double[] targetCheckMol = new double[nCoords];
-            arraycopy(targetXYZOrig, molDist2[index].getIndex() * nCoords, targetCheckMol, 0, nCoords);
-            int minIndex = -1;
-            double minDiff = Double.MAX_VALUE;
-            for (int i = 0; i < baseIndices.length; i++) {
-                double value = doMoleculesMatch(baseXYZs[i], targetCheckMol, mass);
-                value = roundToPlaces(value);
-                if (value < minDiff) {
-                    minDiff = value;
-                    minIndex = i;
-                }
-            }
-            if (!targetBaseindices.contains(baseIndices[minIndex])) {
-                targetdiff.add(minDiff);
-                targetBaseindices.add(baseIndices[minIndex]);
-                targetindices.add(index);
-                target0XYZ.add(targetCheckMol);
-            } else if (Collections.frequency(targetBaseindices, baseIndices[minIndex]) < numSearch2) {
-                targetBaseindices.add(baseIndices[minIndex]);
-                targetdiff.add(minDiff);
-                targetindices.add(index);
-                target0XYZ.add(targetCheckMol);
-            }
-            index++;
-            if (index >= molDist2.length) {
-                break;
-            }
-        }
-        double[] targetDiff = targetdiff.stream().mapToDouble(i -> i).toArray();
+        numberUniqueAUs(targetXYZOrig, molDist2, target0XYZ, targetindices, nCoords, targetSearchValue, exhaustive,
+                nTargetMols, mass, molTol);
         double[][] targetXYZs = new double[target0XYZ.size()][nCoords];
         target0XYZ.toArray(targetXYZs);
         Integer[] targetIndices = new Integer[targetindices.size()];
         targetindices.toArray(targetIndices);
-        Integer[] targetBaseIndices = new Integer[targetBaseindices.size()];
-        targetBaseindices.toArray(targetBaseIndices);
-        if (logger.isLoggable(Level.FINER)) {
-            logger.finer(format(" %d conformations detected out of %d in target crystal.", targetIndices.length, targetSearchValue * numSearch2));
-            logger.finer(" Base Matches:");
-            for (int i = 0; i < baseIndices.length; i++) {
-                logger.finer(format(" %d %4.4f %d", i, baseDiff[i], baseIndices[i]));
+        logger.finer(format(" %d conformations detected out of %d in target crystal.", targetIndices.length, targetSearchValue));
+
+        // Determine which unique AUs are most similar between crystals
+        //Minimum difference between each unique target AU and closest matching base AU.
+        double[] targetBaseDiff = new double[targetIndices.length];
+        // Index of the closest matching base AU to each target AU.
+        int[] targetBaseIndices = new int[targetIndices.length];
+        for(int i = 0; i<targetXYZs.length; i++) {
+            int minIndex = -1;
+            double minDiff = Double.MAX_VALUE;
+            for (int j = 0; j < baseXYZs.length; j++) {
+                double value = RMSD_1(targetXYZs[i], baseXYZs[j], mass);
+                if (value < minDiff) {
+                    minDiff = value;
+                    minIndex = j;
+                }
             }
-            logger.finer(" Target Matches:");
+            targetBaseDiff[i] = minDiff;
+            targetBaseIndices[i] = baseIndices[minIndex];
+        }
+        if (logger.isLoggable(Level.FINER)) {
+            logger.finer(" Minimum RMSD_1 Between Unique Target and Base AUs:\n i tInd RMSD_1    bInd");
             for (int i = 0; i < targetBaseIndices.length; i++) {
-                logger.finer(format(" %d %4.4f %d", i, targetDiff[i], targetBaseIndices[i]));
+                logger.finer(format(" %d %d %4.4f %d", i, targetIndices[i], targetBaseDiff[i], targetBaseIndices[i]));
             }
         }
 
@@ -800,7 +735,7 @@ public class ProgressiveAlignmentOfCrystals {
                     double minDiff = Double.MAX_VALUE;
                     int minIndex = -1;
                     for (int j = 0; j < baseIndices.length; j++) {
-                        double value = doMoleculesMatch(baseXYZs[j], base1of3Mols, mass);
+                        double value = RMSD_1(baseXYZs[j], base1of3Mols, mass);
                         if (value < minDiff) {
                             minDiff = value;
                             minIndex = baseIndices[j];
@@ -826,7 +761,7 @@ public class ProgressiveAlignmentOfCrystals {
                     double minDiff = Double.MAX_VALUE;
                     int minIndex = -1;
                     for (int j = 0; j < baseIndices.length; j++) {
-                        double value = doMoleculesMatch(baseXYZs[j], base1ofNMols, mass);
+                        double value = RMSD_1(baseXYZs[j], base1ofNMols, mass);
                         if (value < minDiff) {
                             minDiff = value;
                             minIndex = baseIndices[j];
@@ -836,7 +771,8 @@ public class ProgressiveAlignmentOfCrystals {
                     logger.finer(format(" %d %4.4f %d", i, minDiff, matchBN[i]));
                 }
             }
-            for (int m = 0; m < targetXYZs.length; m++) {
+            int targetConformations = targetXYZs.length;
+            for (int m = 0; m < targetConformations; m++) {
                 if (exhaustive || Objects.equals(targetBaseIndices[m], baseIndices[l])) {
                     double[] targetXYZ = new double[nTargetMols * nCoords];
                     double[][] targetCoM = new double[nTargetMols][3];
@@ -915,8 +851,6 @@ public class ProgressiveAlignmentOfCrystals {
                     //Update center of masses with the first trans/rot
                     centerOfMass(targetCoM, targetXYZ, mass, massSum);
 
-                    //TODO replace with commented out code. Increased for figure generation
-//            DoubleIndexPair[] matchMols = new DoubleIndexPair[3];
                     DoubleIndexPair[] matchMols = new DoubleIndexPair[Math.max(3, nAU)];
                     matchMolecules(matchMols, baseCoM, targetCoM, molDist1_2, molDist2_2);
 
@@ -966,7 +900,7 @@ public class ProgressiveAlignmentOfCrystals {
                             double minDiff = Double.MAX_VALUE;
                             int minIndex = -1;
                             for (int j = 0; j < baseIndices.length; j++) {
-                                double value = doMoleculesMatch(baseXYZs[j], target1of3Mols, mass);
+                                double value = RMSD_1(baseXYZs[j], target1of3Mols, mass);
                                 if (value < minDiff) {
                                     minDiff = value;
                                     minIndex = baseIndices[j];
@@ -1018,7 +952,7 @@ public class ProgressiveAlignmentOfCrystals {
                             double minDiff = Double.MAX_VALUE;
                             int minIndex = -1;
                             for (int j = 0; j < baseIndices.length; j++) {
-                                double value = doMoleculesMatch(baseXYZs[j], target1ofNMols, mass);
+                                double value = RMSD_1(baseXYZs[j], target1ofNMols, mass);
                                 if (value < minDiff) {
                                     minDiff = value;
                                     minIndex = baseIndices[j];
@@ -1039,8 +973,7 @@ public class ProgressiveAlignmentOfCrystals {
                     double rmsdSymOp = rmsd(baseNMols, targetNMols, massN);
                     if(logger.isLoggable(Level.FINE)){
                         String output = format(" %2d of %2d: %7.4f (%7.4f) %7.4f (%7.4f) %7.4f",
-                                l * numSearch2 + m + 1,
-                                numSearch * numSearch2, checkRMSD1, n1RMSD, checkRMSD2, n3RMSD, rmsdSymOp);
+                                l * targetConformations + m + 1, baseXYZs.length * targetConformations, checkRMSD1, n1RMSD, checkRMSD2, n3RMSD, rmsdSymOp);
 
                         if (logger.isLoggable(Level.FINER)) {
                             //TODO fix conformation comparisons (target system find first available match base has individual
@@ -1223,71 +1156,107 @@ public class ProgressiveAlignmentOfCrystals {
     }
 
     /**
-     * Round a double value to ROUND_PLACES decimal points.
-     *
-     * @param value Double to be rounded.
-     * @return Rounded double.
+     * Determine the number of unique AUs within the replicates crystal to a tolerance.
+     * @param allCoords Coordinates for every atom in replicates crystal ([x1, y1, z1, x2, y2, z2...].
+     * @param molIndices Prioritization of molecules.
+     * @param uniqueXYZs List for atomic coordinates of unique AUs.
+     * @param uniqueIndices List for indices in replicates crystal for unique AUs.
+     * @param nCoords Number of coordinates in an AU (number of atoms * 3).
+     * @param upperLimit The largest number of unique AUs (0 for no upper limit).
+     * @param exhaustive Search entire replicates crystal if true, otherwise only the expected.
+     * @param nAUinReplicates Number of AUs in replicates crystal.
+     * @param mass Array containing masses for each atom in AU.
+     * @param molTol Tolerance to determine whether two molecules are the same.
      */
-    private static double roundToPlaces(double value) {
-        BigDecimal bigDecimal = new BigDecimal(Double.toString(value));
-        bigDecimal = bigDecimal.setScale(ROUND_PLACES, RoundingMode.HALF_UP);
-        return bigDecimal.doubleValue();
+    private static void numberUniqueAUs(double[] allCoords, DoubleIndexPair[] molIndices, ArrayList<double[]> uniqueXYZs,
+                                       List<Integer> uniqueIndices, int nCoords, int upperLimit, boolean exhaustive,
+                                        int nAUinReplicates, double[] mass, double molTol){
+        // uniqueDiffs is only recorded for logging... could remove later.
+        // List of differences (RMSD_1) for AUs in replicates crystal.
+        List<Double> uniqueDiffs = new ArrayList<>();
+        double[] tempBase = new double[nCoords];
+        arraycopy(allCoords, molIndices[0].getIndex() * nCoords, tempBase, 0, nCoords);
+        uniqueIndices.add(0);
+        uniqueDiffs.add(rmsd(tempBase, tempBase, mass));
+        uniqueXYZs.add(tempBase);
+        // Start from 1 as zero is automatically added.
+        int index = 1;
+        //Determine number of conformations in first crystal
+        int numConfCheck = (exhaustive || upperLimit <= 0) ? nAUinReplicates : upperLimit;
+        logger.finer("RMSD Differences in Replicates Crystal:");
+        while (uniqueDiffs.size() < numConfCheck) {
+            double[] baseCheckMol = new double[nCoords];
+            arraycopy(allCoords, molIndices[index].getIndex() * nCoords, baseCheckMol, 0,
+                    nCoords);
+            double value = RMSD_1(uniqueXYZs.get(0), baseCheckMol, mass);
+            logger.finer(format("%d %4.4f", molIndices[index].getIndex(), value));
+            if (addLooseUnequal(uniqueDiffs, value, molTol)) {
+                uniqueIndices.add(index);
+                uniqueXYZs.add(baseCheckMol);
+            }
+            index++;
+            if (index >= molIndices.length) {
+                break;
+            }
+        }
+        if (logger.isLoggable(Level.FINER)) {
+            logger.finer(" RMSD_1 from 1st AU:\n i AUIndex RMSD");
+            for (int i = 0; i < uniqueIndices.size(); i++) {
+                logger.finer(format(" %d %4.4f %d", i, uniqueDiffs.get(i), uniqueIndices.get(i)));
+            }
+        }
     }
 
     /**
-     * Perform first rotation to match center most molecules.
+     * Perform first rotation to match center most AUs.
      *
      * @param targetXYZ Coordinates for second system.
      * @param mass      Masses for atoms in a molecule.
-     * @param baseXYZ   Coordinates for first system.
-     * @param index2    Index of
+     * @param baseAUXYZ Coordinates for AU in first system.
+     * @param index    Index of target AU to move to base AU.
      */
-    private static void firstRotation(double[] targetXYZ, double[] mass, double[] baseXYZ, int index2) {
-        int nAtoms = mass.length;
-        int nCoords = nAtoms * 3;
+    private static void firstRotation(double[] targetXYZ, double[] mass, double[] baseAUXYZ, int index) {
+        translateAUtoOrigin(targetXYZ, mass, index);
 
         // Copy base and target coordinates for the center molecule.
+        int nAtoms = mass.length;
+        int nCoords = nAtoms * 3;
         double[] targetMol = new double[nCoords];
-        int targetIndex = index2 * nCoords;
+        int targetIndex = index * nCoords;
         arraycopy(targetXYZ, targetIndex, targetMol, 0, nCoords);
 
-        // Translate the center of mass to the origin.
-        double[] translation = calculateTranslation(targetMol, mass);
-        applyTranslation(targetMol, translation);
-        applyTranslation(targetXYZ, translation);
-
         // Rotate the target molecule onto the base molecule.
-        double[][] rotation = calculateRotation(baseXYZ, targetMol, mass);
+        double[][] rotation = calculateRotation(baseAUXYZ, targetMol, mass);
         applyRotation(targetXYZ, rotation);
     }
 
     /**
      * Translate an asymmetric unit to the origin.
      *
-     * @param baseXYZ Coordinates of the system
+     * @param systemXYZ Coordinates of the system
      * @param mass    Masses of atoms in one asymmetric unit.
      * @param index   Index of the asymmetric unit to move.
      */
-    private static void translateAUtoOrigin(double[] baseXYZ, double[] mass, int index) {
+    private static void translateAUtoOrigin(double[] systemXYZ, double[] mass, int index) {
         int nAtoms = mass.length;
         int nCoords = nAtoms * 3;
 
         // Load the coordinates.
-        double[] baseMol = new double[nCoords];
-        int baseIndex = index * nCoords;
-        arraycopy(baseXYZ, baseIndex, baseMol, 0, nCoords);
+        double[] AUCoords = new double[nCoords];
+        int AUIndex = index * nCoords;
+        arraycopy(systemXYZ, AUIndex, AUCoords, 0, nCoords);
 
-        double[] translateBase = calculateTranslation(baseMol, mass);
-        applyTranslation(baseXYZ, translateBase);
+        double[] translation = calculateTranslation(AUCoords, mass);
+        applyTranslation(systemXYZ, translation);
     }
 
     /**
      * Perform second rotation to better match crystal systems.
      *
-     * @param base3Mols Coordinates for system 1
+     * @param base3Mols Coordinates for center 3 AUs in first system.
      * @param targetXYZ Coordinates for system 2
-     * @param mass      Masses for atoms in one molecule
-     * @param matchMols Indices for system 2 that match molecules in system 1
+     * @param mass      Masses for atoms in three AUs.
+     * @param matchMols Indices for system 2 that match AUs in system 1
      */
     private static void secondRotation(double[] base3Mols, double[] targetXYZ, double[] mass,
                                        DoubleIndexPair[] matchMols) {
@@ -1360,14 +1329,14 @@ public class ProgressiveAlignmentOfCrystals {
     }
 
     /**
-     * Determine if two species are of the same conformation (should be same species).
+     * Determine the RMSD between two AUs (should be same AUs).
      *
-     * @param baseXYZ   One species.
-     * @param targetXYZ Second species.
-     * @param mass      Mass of atoms within species
-     * @return RMSD between both species.
+     * @param baseXYZ   Coordinates for first AU.
+     * @param targetXYZ Coordinates for second AU.
+     * @param mass      Mass of atoms within AU.
+     * @return RMSD between AUs.
      */
-    private static double doMoleculesMatch(double[] baseXYZ, double[] targetXYZ, double[] mass) {
+    private static double RMSD_1(double[] baseXYZ, double[] targetXYZ, double[] mass) {
         translate(baseXYZ, mass, targetXYZ, mass);
         rotate(baseXYZ, targetXYZ, mass);
         return rmsd(baseXYZ, targetXYZ, mass);
@@ -1843,9 +1812,20 @@ public class ProgressiveAlignmentOfCrystals {
      * @param value  Potential new value if it is not already in list.
      */
     private static boolean addLooseUnequal(List<Double> values, double value) {
+        return addLooseUnequal(values, value, MATCH_TOLERANCE);
+    }
+
+    /**
+     * Add a value to a list of doubles if its difference to all listed values is greater than the
+     * tolerance.
+     *
+     * @param values List of values already found.
+     * @param value  Potential new value if it is not already in list.
+     */
+    private static boolean addLooseUnequal(List<Double> values, double value, double tol) {
         boolean found = false;
         for (Double dbl : values) {
-            if (abs(dbl - value) < MATCH_TOLERANCE) {
+            if (abs(dbl - value) < tol) {
                 found = true;
                 break;
             }
@@ -2055,3 +2035,5 @@ public class ProgressiveAlignmentOfCrystals {
 //            logger.finer(format(" DONE N3: %16.15f %16.15f %16.15f", p1n3, q1n3, r1n3));
 //        }
 //    }
+
+//  Frank-Kasper phases of metallic ions can reach a coordination number of 16...

--- a/modules/potential/src/test/java/ffx/potential/groovy/CIFtoXYZTest.java
+++ b/modules/potential/src/test/java/ffx/potential/groovy/CIFtoXYZTest.java
@@ -60,6 +60,7 @@ public class CIFtoXYZTest extends PotentialTest {
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
     // Construct and evaluate the CIFtoXYZ script.
+
     CIFtoXYZ cifToXYZ = new CIFtoXYZ(binding).run();
     potentialScript = cifToXYZ;
   }
@@ -67,7 +68,7 @@ public class CIFtoXYZTest extends PotentialTest {
   @Test
   public void testCIFtoXYZNoHydrogen() {
     // Set-up the input arguments for the CIFtoXYZ script.
-    String[] args = {"src/main/java/ffx/potential/structures/CBZ03.cif",
+    String[] args = {"--fl","src/main/java/ffx/potential/structures/CBZ03.cif",
         "src/main/java/ffx/potential/structures/cbz.xyz"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());


### PR DESCRIPTION
SuperposeCrystals: Changed class integers to private. Removed a redundant flag ("removeEquivalent"). Consolidated "lowDensity" and "fileOrder" flags to "PrioritizeCrystals" flag.

ProgressiveAlignmentOfCrystals: Updated flags as stated above. Correctly transfer variables when switching crystal ordering.

SpaceGroupDefinitions: When searching through space groups removes spaces from common name search (PDB space group search unaffected).

SpaceGroupConversions: Updated handling, variable names, and comments when performing conversions between hexagonal and rhombohedral space groups.

CIFtoXYZ: Improved handling of mislabeled hexagonal/rhombohedral space groups. Improved detection for CIF files that have Z'>1 and no hydrogens. Updated output file name. Script is now compatible with "forcefield" values from property/key file. Script keeps an array of created output files (useful for automation/use in other scripts) and added a getter for this array.

CIFtoXYZTest: Updated one of the tests to properly convert the input file from rhombohedral to hexagonal (added "--fl" to arguments).