### PR TITLE
Recent update broke Z'>1 conversion.

### DIFF
--- a/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/CIFtoXYZ.groovy
@@ -55,16 +55,16 @@ import static org.apache.commons.io.FilenameUtils.removeExtension
  * <br>
  * Usage:
  * <br>
- * ffxc CIFtoXYZ &lt;filename.cif&gt; &lt;filename.pdb&gt;
+ * ffxc CIFtoXYZ &lt;filename.cif&gt; &lt;filename.xyz&gt;
  */
 @Command(description = " Convert a single molecule CIF file to XYZ format.", name = "ffxc CIFtoXYZ")
 class CIFtoXYZ extends PotentialScript {
 
   /**
-   * --sg or --spaceGroupNumber Manually specify Z' (only affects writing CIF files)."
+   * --zp or --zPrime Manually specify Z' (only affects writing CIF files)."
    */
   @Option(names = ['--zp', '--zPrime'], paramLabel = "-1", defaultValue = "-1",
-          description = 'Specify Z\' when writing a CIF file.')
+          description = "Specify Z' when writing a CIF file.")
   private int zPrime
 
   /**

--- a/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
@@ -467,7 +467,7 @@ public class CIFFilter extends SystemFilter{
                     }
                 }
                 if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(format(" Current Entity Number of Atoms: %d (%d + %dH)", numXYZMolAtoms, numXYZMolAtoms - numHydrogens, numHydrogens));
+                    logger.fine(format(" Current Entity Number of Atoms: %d (%d + %dH)", numXYZMolAtoms, numXYZMolAtoms - numMolHydrogens, numMolHydrogens));
                 }
 
                 // Set up XYZ file contents as CDK variable
@@ -734,14 +734,14 @@ public class CIFFilter extends SystemFilter{
                                 if (p != null && logger.isLoggable(Level.FINE)) {
                                     logger.fine(
                                             format(" Matched %d atoms out of %d in CIF (%d in XYZ)", p.length, nAtoms,
-                                                    nXYZAtoms - numHydrogens));
+                                                    nXYZAtoms - numMolHydrogens));
                                 }
                                 continue;
                             }
                         } else {
                             logger.info(
                                     format(" CIF (%d) and XYZ ([%d+%dH=]%d) have a different number of bonds.", cifMolBonds,
-                                            xyzBonds - numHydrogens, numHydrogens, xyzBonds));
+                                            xyzBonds - numMolHydrogens, numMolHydrogens, xyzBonds));
                             continue;
                         }
                         cifCDKAtoms.add(cifCDKAtomsArr[j]);
@@ -769,15 +769,21 @@ public class CIFFilter extends SystemFilter{
                     } else {
                         if (logger.isLoggable(Level.FINE)) {
                             logger.fine(format(" Number of atoms in CIF (%d) molecule do not match XYZ (%d + %dH = %d).",
-                                    cifMolAtoms, nXYZAtoms - numHydrogens, numHydrogens, nXYZAtoms));
+                                    cifMolAtoms, nXYZAtoms - numMolHydrogens, numMolHydrogens, nXYZAtoms));
                         }
                     }
                 }
             }
             // If no atoms, then conversion has failed... use active assembly
             if (logger.isLoggable(Level.FINE)) {
-                logger.fine(format(" Output Assembly Size: %d", outputAssembly.getAtomList().size()));
+                logger.fine(format("\n Output Assembly Atoms: %d", outputAssembly.getAtomList().size()));
             }
+            outputAssembly.setPotential(activeMolecularAssembly.getPotentialEnergy());
+            outputAssembly.setCrystal(crystal);
+            outputAssembly.setForceField(activeMolecularAssembly.getForceField());
+            outputAssembly.setFile(activeMolecularAssembly.getFile());
+            outputAssembly.setName(activeMolecularAssembly.getName());
+            setMolecularSystem(outputAssembly);
 
             if (outputAssembly.getAtomList().size() < 1 || !writeXYZFile()) {
                 logger.info(" No atoms were written to XYZ file. Conversion failed.");


### PR DESCRIPTION
CIFtoXYZ: Refactoring of CIFFilter broke the conversion of structures where Z'>1 (only the first entity in asymmetric unit would be saved). I fixed that and had a few minor logging tweaks.