### PR TITLE
PAC improvements and DualTopology edits

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -84,9 +84,9 @@ class SuperposeCrystals extends AlgorithmsScript {
   /**
    * --ni or --numInflatedAU Inflation factor used to determine replicates expansion.
    */
-  @Option(names = ['--ni', '--numInflatedAU'], paramLabel = '4', defaultValue = '4',
+  @Option(names = ['--ni', '--numInflatedAU'], paramLabel = '4.25', defaultValue = '4.25',
       description = 'Inflation factor used to determine replicates expansion.')
-  private int numInflatedAU
+  private double numInflatedAU
 
   /**
    * --zp or --zPrime Z' for crystal 1 (-1 to autodetect).

--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -82,10 +82,10 @@ class SuperposeCrystals extends AlgorithmsScript {
   private int numAU
 
   /**
-   * --ni or --numInflatedAU AUs in the expanded crystal.
+   * --ni or --numInflatedAU Inflation factor used to determine replicates expansion.
    */
-  @Option(names = ['--ni', '--numInflatedAU'], paramLabel = '500', defaultValue = '500',
-      description = 'AUs in the expanded crystal.')
+  @Option(names = ['--ni', '--numInflatedAU'], paramLabel = '4', defaultValue = '4',
+      description = 'Inflation factor used to determine replicates expansion.')
   private int numInflatedAU
 
   /**
@@ -145,11 +145,11 @@ class SuperposeCrystals extends AlgorithmsScript {
   private static boolean alphaCarbons
 
   /**
-   * --nh or --noHydrogen Ignore hydrogen atoms.
+   * --ih or --includeHydrogen Include hydrogen atoms.
    */
-  @Option(names = ['--nh', '--noHydrogen'], paramLabel = "false", defaultValue = "false",
-      description = 'Ignore hydrogen atoms.')
-  private static boolean noHydrogen
+  @Option(names = ['--ih', '--includeHydrogen'], paramLabel = "false", defaultValue = "false",
+      description = 'Include hydrogen atoms.')
+  private static boolean includeHydrogen
 
   /**
    * --sm or --saveMachineLearning Save out PDB and CSV for machine learning.
@@ -189,7 +189,7 @@ class SuperposeCrystals extends AlgorithmsScript {
   /**
    * -l or --linkage Single (0), Average (1), or Complete (2) coordinate linkage for molecule prioritization.
    */
-  @Option(names = ['-l', '--linkage'], paramLabel = '0', defaultValue = '0',
+  @Option(names = ['-l', '--linkage'], paramLabel = '1', defaultValue = '1',
       description = 'Single (0), Average (1), or Complete (2) coordinate linkage for molecule prioritization.')
   private int linkage
 
@@ -289,7 +289,7 @@ class SuperposeCrystals extends AlgorithmsScript {
 
     runningStatistics =
         pac.comparisons(numAU, numInflatedAU, matchTol, zPrime, zPrime2, alphaCarbons,
-            noHydrogen, massWeighted, crystalPriority, permute, save,
+            includeHydrogen, massWeighted, crystalPriority, permute, save,
             restart, write, machineLearning, inertia, gyrationComponents, linkage, printSym, pacFilename)
 
     return this

--- a/modules/algorithms/src/main/java/ffx/algorithms/optimize/manybody/BoxOptCell.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/optimize/manybody/BoxOptCell.java
@@ -130,7 +130,7 @@ public class BoxOptCell {
     atXYZ = atom.getXYZ(atXYZ);
     crystal.toFractionalCoordinates(atXYZ, atXYZ);
     NeighborList.moveValuesBetweenZeroAndOne(atXYZ);
-    crystal.applyFracSymOp(atXYZ, atXYZ, symOp);
+    Crystal.applyFracSymOp(atXYZ, atXYZ, symOp);
     return checkIfContained(atXYZ);
   }
 

--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
@@ -52,13 +52,12 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
 
   private final double tolerance = 0.001;
 
-  // TODO: add more tests with more parameters
   /** Tests the SuperposeCrystals script with default settings. */
   @Test
   public void testBaseSingleSuperposeCrystals() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"src/main/java/ffx/algorithms/structures/C23.arc"};
+    String[] args = {"-l", "0", "src/main/java/ffx/algorithms/structures/C23.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -69,15 +68,15 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.113573, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.087248, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
-  /** Tests the SuperposeCrystals script with crystal size of one. */
+  /** Tests the SuperposeCrystals script with RMSD size of one. */
   @Test
-  public void testBaseSingleCrystalSuperposeCrystals() {
+  public void testBaseSingleAUSuperposeCrystals() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--na","1","src/main/java/ffx/algorithms/structures/C23.arc"};
+    String[] args = {"--na","1","-l", "0", "src/main/java/ffx/algorithms/structures/C23.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -88,7 +87,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.088323, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.055486, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the SuperposeCrystals script with default settings and average linkage. */
@@ -107,15 +106,15 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.11101375, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.083089, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
-  /** Tests the SuperposeCrystals script without hydrogens. */
+  /** Tests the SuperposeCrystals script with hydrogens. */
   @Test
-  public void testBaseAverageSuperposeCrystalsNoHydrogen() {
+  public void testBaseAverageSuperposeCrystalsHydrogen() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "-l", "1", "src/main/java/ffx/algorithms/structures/C23.arc"};
+    String[] args = {"--ih", "-l", "1", "src/main/java/ffx/algorithms/structures/C23.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -126,15 +125,15 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.0825498666, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.111014, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
-  /** Tests the SuperposeCrystals script without hydrogens. */
+  /** Tests the SuperposeCrystals script with hydrogens. */
   @Test
-  public void testBaseSingleSuperposeCrystalsNoHydrogen() {
+  public void testBaseSingleSuperposeCrystalsHydrogen() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "src/main/java/ffx/algorithms/structures/C23.arc"};
+    String[] args = {"--ih","-l", "0", "src/main/java/ffx/algorithms/structures/C23.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -145,7 +144,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.088094, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.112556, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the SuperposeCrystals script in Sohncke group. */
@@ -153,7 +152,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseAverageSuperposeCrystalsSohnckeGroup() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "-l", "1", "src/main/java/ffx/algorithms/structures/dap.xyz",
+    String[] args = {"-l", "1", "src/main/java/ffx/algorithms/structures/dap.xyz",
             "src/main/java/ffx/algorithms/structures/dap.xyz_close"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
@@ -170,7 +169,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseSingleSuperposeCrystalsSohnckeGroup() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "src/main/java/ffx/algorithms/structures/dap.xyz",
+    String[] args = {"-l","0", "src/main/java/ffx/algorithms/structures/dap.xyz",
         "src/main/java/ffx/algorithms/structures/dap.xyz_close"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
@@ -187,7 +186,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseAverageSuperposeCrystalsHandedness() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "-l", "1", "src/main/java/ffx/algorithms/structures/dap2.xyz",
+    String[] args = {"-l", "1", "src/main/java/ffx/algorithms/structures/dap2.xyz",
             "src/main/java/ffx/algorithms/structures/dap2.xyz_2"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
@@ -196,7 +195,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.1149806, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.112274, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the SuperposeCrystals script on tricky handedness case. */
@@ -204,7 +203,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseSingleSuperposeCrystalsHandedness() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "src/main/java/ffx/algorithms/structures/dap2.xyz",
+    String[] args = {"-l","0","src/main/java/ffx/algorithms/structures/dap2.xyz",
         "src/main/java/ffx/algorithms/structures/dap2.xyz_2"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
@@ -213,7 +212,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.099021, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.098483, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the SuperposeCrystals script on asymmetric unit greater than one. */
@@ -221,7 +220,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseAverageSuperposeCrystalsZPrime2() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "-l", "1", "src/main/java/ffx/algorithms/structures/XAFPAY02.arc"};
+    String[] args = {"-l", "1", "src/main/java/ffx/algorithms/structures/XAFPAY02.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -232,7 +231,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.15314780346762857, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.151675, superposeCrystals.runningStatistics.getMean(), tolerance);
   }
 
   /** Tests the SuperposeCrystals script on asymmetric unit greater than one. */
@@ -240,7 +239,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseSingleSuperposeCrystalsZPrime2() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "src/main/java/ffx/algorithms/structures/XAFPAY02.arc"};
+    String[] args = {"-l","0", "src/main/java/ffx/algorithms/structures/XAFPAY02.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -259,7 +258,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
   public void testBaseSingleSuperposeCrystalsSmallProtein() {
 
     // Set-up the input arguments for the SuperposeCrystals script.
-    String[] args = {"--nh", "src/main/java/ffx/algorithms/structures/2olx.arc"};
+    String[] args = {"-l","0", "src/main/java/ffx/algorithms/structures/2olx.arc"};
     binding.setVariable("args", args);
     binding.setVariable("baseDir", registerTemporaryDirectory().toFile());
 
@@ -270,8 +269,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.476837, superposeCrystals.runningStatistics.getMean(), tolerance);
-    assertEquals(1.379653, superposeCrystals.runningStatistics.getMax(), tolerance);
+    assertEquals(0.478175, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(1.383652, superposeCrystals.runningStatistics.getMax(), tolerance);
   }
 
   @Test

--- a/modules/crystal/src/main/java/ffx/crystal/Crystal.java
+++ b/modules/crystal/src/main/java/ffx/crystal/Crystal.java
@@ -543,7 +543,7 @@ public class Crystal {
    * @param mateZ Output cartesian z-coordinates.
    * @param symOp The cartesian symmetry operator.
    */
-  public void applyCartSymOp(
+  public static void applyCartSymOp(
       int n,
       double[] x,
       double[] y,
@@ -601,7 +601,7 @@ public class Crystal {
    * @param mate Symmetry mate  cartesian coordinates.
    * @param symOp The cartesian symmetry operator.
    */
-  public void applyCartesianSymOp(double[] xyz, double[] mate, SymOp symOp) {
+  public static void applyCartesianSymOp(double[] xyz, double[] mate, SymOp symOp) {
     double[][] rot = symOp.rot;
     double[] trans = symOp.tr;
     double xc = xyz[0];
@@ -620,7 +620,7 @@ public class Crystal {
    * @param mate Symmetry mate fractional coordinates.
    * @param symOp The fractional symmetry operator.
    */
-  public void applyFracSymOp(double[] xyz, double[] mate, SymOp symOp) {
+  public static void applyFracSymOp(double[] xyz, double[] mate, SymOp symOp) {
     double[][] rot = symOp.rot;
     double[] trans = symOp.tr;
     double xf = xyz[0];
@@ -717,7 +717,7 @@ public class Crystal {
    * @param ny number of unit cell translations
    * @param nz number of unit cell translations
    */
-  public void applySymOp(int h, int k, int l, int[] mate, SymOp symOp, int nx, int ny, int nz) {
+  public static void applySymOp(int h, int k, int l, int[] mate, SymOp symOp, int nx, int ny, int nz) {
     double[][] rot = symOp.rot;
     double[] trans = symOp.tr;
     // Apply Symmetry Operator.
@@ -795,7 +795,7 @@ public class Crystal {
    * @param mate Symmetry mate HKL.
    * @param symOp The symmetry operator.
    */
-  public void applySymRot(HKL hkl, HKL mate, SymOp symOp) {
+  public static void applySymRot(HKL hkl, HKL mate, SymOp symOp) {
     double[][] rot = symOp.rot;
     double h = hkl.h();
     double k = hkl.k();
@@ -857,6 +857,41 @@ public class Crystal {
   }
 
   /**
+   * Apply a Cartesian symmetry rotation to an array of Cartesian coordinates. The length of xyz must be divisible by
+   * 3 and mate must have the same length.
+   *
+   * @param xyz Input cartesian x, y, z-coordinates.
+   * @param mate Output cartesian x, y, z-coordinates.
+   * @param symOp The fractional symmetry operator.
+   */
+  public static void applyCartesianSymRot(double[] xyz, double[] mate, SymOp symOp) {
+    int l = xyz.length;
+    assert(l % 3 == 0);
+    assert(mate.length == l);
+    double[][] rot = symOp.rot;
+    final double rot00 = rot[0][0];
+    final double rot10 = rot[1][0];
+    final double rot20 = rot[2][0];
+    final double rot01 = rot[0][1];
+    final double rot11 = rot[1][1];
+    final double rot21 = rot[2][1];
+    final double rot02 = rot[0][2];
+    final double rot12 = rot[1][2];
+    final double rot22 = rot[2][2];
+    int n = l/3;
+    for (int i = 0; i < n; i++) {
+      int j = i * 3;
+      double xi = xyz[j];
+      double yi = xyz[j + 1];
+      double zi = xyz[j + 2];
+      // Apply Symmetry Operator.
+      mate[j] = rot00 * xi + rot01 * yi + rot02 * zi;
+      mate[j + 1] = rot10 * xi + rot11 * yi + rot12 * zi;
+      mate[j + 2] = rot20 * xi + rot21 * yi + rot22 * zi;
+    }
+  }
+
+  /**
    * .Apply the rotation of a fractional symmetry operator to cartesian coordinates.
    *
    * @param xyz Input coordinates.
@@ -880,7 +915,7 @@ public class Crystal {
    * @param mate Symmetry mate HKL.
    * @param symOp The symmetry operator.
    */
-  public void applyTransSymRot(HKL hkl, HKL mate, SymOp symOp) {
+  public static void applyTransSymRot(HKL hkl, HKL mate, SymOp symOp) {
     double[][] rot = symOp.rot;
     double h = hkl.h();
     double k = hkl.k();

--- a/modules/crystal/src/main/java/ffx/crystal/ReflectionList.java
+++ b/modules/crystal/src/main/java/ffx/crystal/ReflectionList.java
@@ -316,9 +316,9 @@ public class ReflectionList {
 
     for (int i = 0; i < nsym; i++) {
       if (transpose) {
-        crystal.applyTransSymRot(hkl, mate, spaceGroup.symOps.get(i));
+        Crystal.applyTransSymRot(hkl, mate, spaceGroup.symOps.get(i));
       } else {
-        crystal.applySymRot(hkl, mate, spaceGroup.symOps.get(i));
+        Crystal.applySymRot(hkl, mate, spaceGroup.symOps.get(i));
       }
 
       LaueSystem laueSystem = spaceGroup.laueSystem;
@@ -359,7 +359,7 @@ public class ReflectionList {
     int nsym = spaceGroup.symOps.size();
     for (int i = 1; i < nsym; i++) {
       HKL mate = new HKL();
-      crystal.applySymRot(hkl, mate, spaceGroup.symOps.get(i));
+      Crystal.applySymRot(hkl, mate, spaceGroup.symOps.get(i));
       double shift = Crystal.sym_phase_shift(hkl, spaceGroup.symOps.get(i));
 
       if (mate.equals(hkl)) {

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/PrepareSpaceGroups.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/PrepareSpaceGroups.groovy
@@ -250,7 +250,7 @@ class PrepareSpaceGroups extends PotentialScript {
         double[] xyz = new double[3]
         for (int i = 0; i < atoms.length; i++) {
           atoms[i].getXYZ(xyz)
-          crystal.applyCartesianSymOp(xyz, xyz, symOp)
+          Crystal.applyCartesianSymOp(xyz, xyz, symOp)
           atoms[i].setXYZ(xyz)
         }
       }

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/SaveAsXYZ.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/SaveAsXYZ.groovy
@@ -168,7 +168,7 @@ class SaveAsXYZ extends PotentialScript {
       double[] xyz = new double[3]
       for (int i = 0; i < atoms.length; i++) {
         atoms[i].getXYZ(xyz)
-        crystal.applyCartesianSymOp(xyz, xyz, symOp)
+        Crystal.applyCartesianSymOp(xyz, xyz, symOp)
         atoms[i].setXYZ(xyz)
       }
     }

--- a/modules/potential/src/main/java/ffx/potential/MolecularAssembly.java
+++ b/modules/potential/src/main/java/ffx/potential/MolecularAssembly.java
@@ -320,7 +320,7 @@ public class MolecularAssembly extends MSGroup {
               moleculeNum, symOp));
       for (Atom atom : atoms) {
         atom.getXYZ(xyz);
-        crystal.applyCartesianSymOp(xyz, xyz, symOp);
+        Crystal.applyCartesianSymOp(xyz, xyz, symOp);
         atom.setXYZ(xyz);
       }
       moleculeNum++;

--- a/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
@@ -494,6 +494,7 @@ public class CIFFilter extends SystemFilter{
                 int xyzBonds = bonds.size();
                 if(xyzBonds <= 0){
                     logger.warning(" XYZ structure has no bonds... Check input.");
+                    continue;
                 }
                 for (Bond xyzBond : bonds) {
                     if (logger.isLoggable(Level.FINE)) {

--- a/modules/xray/src/main/java/ffx/xray/CrystalReciprocalSpace.java
+++ b/modules/xray/src/main/java/ffx/xray/CrystalReciprocalSpace.java
@@ -1138,7 +1138,7 @@ public class CrystalReciprocalSpace {
       // apply symmetry
       for (int j = 0; j < nsym; j++) {
         cj.copy(c);
-        crystal.applyTransSymRot(ih, ij, symops.get(j));
+        Crystal.applyTransSymRot(ih, ij, symops.get(j));
         double shift = Crystal.sym_phase_shift(ih, symops.get(j));
 
         int h = Crystal.mod(ij.h(), fftX);
@@ -3683,7 +3683,7 @@ public class CrystalReciprocalSpace {
           double[] fc = hkldata[ih.index()];
           // Apply symmetry
           for (int j = 0; j < nsym; j++) {
-            crystal.applyTransSymRot(ih, ij, symops.get(j));
+            Crystal.applyTransSymRot(ih, ij, symops.get(j));
             double shift = Crystal.sym_phase_shift(ih, symops.get(j));
             int h = Crystal.mod(ij.h(), fftX);
             int k = Crystal.mod(ij.k(), fftY);


### PR DESCRIPTION
PAC: Optimized default input parameters. Updated unit test with new default parameters. Added translation to both systems before rotation 2 occurs on mobile system. New heuristic to determine inflated sphere size rather than previous flat value. Updated printSym to print out string as input to DualTopologyEnergy.

DualTopologyEnergy: First pass at incorporation of SymOp. Added property (-Dsymop="a b c al be ga"). Still need to updated get/setCrystal methods (added a warning to notify user that crystal was overwritten.

Crystal: Updated several SymOp methods to static. Added new SymOp method to apply a SymOp to a system of coordinates.

CIFFilter: Added continue if a loop is unable to find XYZ bonds (used to result in error).

Others: Updates to satisfy static methods from Crystal.