### PR TITLE
Adjusted PAC parameters and minor crystal DT update.

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -82,11 +82,11 @@ class SuperposeCrystals extends AlgorithmsScript {
   private int numAU
 
   /**
-   * --ni or --numInflatedAU Inflation factor used to determine replicates expansion.
+   * --if or --inflationFactor Inflation factor used to determine replicates expansion.
    */
-  @Option(names = ['--ni', '--numInflatedAU'], paramLabel = '4.25', defaultValue = '4.25',
+  @Option(names = ['--if', '--inflationFactor'], paramLabel = '2.90', defaultValue = '2.90',
       description = 'Inflation factor used to determine replicates expansion.')
-  private double numInflatedAU
+  private double inflationFactor
 
   /**
    * --zp or --zPrime Z' for crystal 1 (-1 to autodetect).
@@ -105,7 +105,7 @@ class SuperposeCrystals extends AlgorithmsScript {
   /**
    * --mt or --matchTolerance Tolerance to determine if two AUs are different.
    */
-  @Option(names = ['--mt', '--moleculeTolerance'], paramLabel = '0.1', defaultValue = '0.1',
+  @Option(names = ['--mt', '--moleculeTolerance'], paramLabel = '0.007', defaultValue = '0.007',
           description = "Tolerance to determine if two AUs are different.")
   private double matchTol
 
@@ -288,7 +288,7 @@ class SuperposeCrystals extends AlgorithmsScript {
     String pacFilename = concat(getFullPath(filename), getBaseName(filename) + ".txt")
 
     runningStatistics =
-        pac.comparisons(numAU, numInflatedAU, matchTol, zPrime, zPrime2, alphaCarbons,
+        pac.comparisons(numAU, inflationFactor, matchTol, zPrime, zPrime2, alphaCarbons,
             includeHydrogen, massWeighted, crystalPriority, permute, save,
             restart, write, machineLearning, inertia, gyrationComponents, linkage, printSym, pacFilename)
 

--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 
 public class SuperposeCrystalsTest extends AlgorithmsTest {
 
-  private final double tolerance = 0.001;
+  private final double TOLERANCE = 0.001;
 
   /** Tests the SuperposeCrystals script with default settings. */
   @Test
@@ -68,7 +68,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.087248, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.082798, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.216710, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script with RMSD size of one. */
@@ -87,7 +88,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.055486, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.055486, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.161867, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script with default settings and average linkage. */
@@ -106,7 +108,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.083089, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.080817, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.213987, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script with hydrogens. */
@@ -125,7 +128,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.111014, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.111014, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.297522, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script with hydrogens. */
@@ -144,7 +148,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     // Only off-diagonal values.
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
-    assertEquals(0.112556, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.111039, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.300095, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script in Sohncke group. */
@@ -161,7 +166,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.066569, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.066569, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script in Sohncke group. */
@@ -178,7 +183,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.073036, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.073036, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script on tricky handedness case. */
@@ -195,7 +200,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.112274, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.112274, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script on tricky handedness case. */
@@ -212,7 +217,7 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     SuperposeCrystals superposeCrystals = new SuperposeCrystals(binding).run();
     algorithmsScript = superposeCrystals;
 
-    assertEquals(0.098483, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.098483, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script on asymmetric unit greater than one. */
@@ -231,7 +236,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.151675, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.151675, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.375328, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script on asymmetric unit greater than one. */
@@ -250,7 +256,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.143013, superposeCrystals.runningStatistics.getMean(), tolerance);
+    assertEquals(0.145739, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(0.362522, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   /** Tests the SuperposeCrystals script on protein crystal. */
@@ -269,8 +276,8 @@ public class SuperposeCrystalsTest extends AlgorithmsTest {
     assertEquals(6, superposeCrystals.runningStatistics.getCount());
     // Mean RMSD for 6 comparisons.
 
-    assertEquals(0.478175, superposeCrystals.runningStatistics.getMean(), tolerance);
-    assertEquals(1.383652, superposeCrystals.runningStatistics.getMax(), tolerance);
+    assertEquals(0.478175, superposeCrystals.runningStatistics.getMean(), TOLERANCE);
+    assertEquals(1.383652, superposeCrystals.runningStatistics.getMax(), TOLERANCE);
   }
 
   @Test

--- a/modules/crystal/src/main/java/ffx/crystal/Crystal.java
+++ b/modules/crystal/src/main/java/ffx/crystal/Crystal.java
@@ -40,9 +40,7 @@ package ffx.crystal;
 import static ffx.numerics.math.DoubleMath.dot;
 import static ffx.numerics.math.DoubleMath.length;
 import static ffx.numerics.math.DoubleMath.sub;
-import static ffx.numerics.math.MatrixMath.mat3Mat3;
-import static ffx.numerics.math.MatrixMath.mat3SymVec6;
-import static ffx.numerics.math.MatrixMath.transpose3;
+import static ffx.numerics.math.MatrixMath.*;
 import static ffx.utilities.Constants.AVOGADRO;
 import static ffx.utilities.StringUtils.padRight;
 import static java.lang.String.format;
@@ -1336,6 +1334,16 @@ public class Crystal {
       }
     }
     return false;
+  }
+
+  /**
+   * Invert a symmetry operator.
+   * @param symOp Original symmetry operator of which the inverse is desired.
+   * @return SymOp The inverse symmetry operator of the one supplied.
+   */
+  public static SymOp invertSymOp(SymOp symOp){
+    double[] tr =  symOp.tr;
+    return new SymOp(mat3Inverse(symOp.rot), new double[]{-tr[0], -tr[1], -tr[2]});
   }
 
   /**

--- a/modules/numerics/src/main/java/ffx/numerics/math/MatrixMath.java
+++ b/modules/numerics/src/main/java/ffx/numerics/math/MatrixMath.java
@@ -141,6 +141,51 @@ public final class MatrixMath {
   }
 
   /**
+   * Matrix times a matrix (both 4x4).
+   *
+   * @param m1 First input matrix.
+   * @param m2 Second input matrix.
+   * @return Returns the matrix product.
+   */
+  public static double[][] mat4Mat4(double[][] m1, double[][] m2) {
+    return mat4Mat4(m1, m2, new double[4][4]);
+  }
+
+  /**
+   * Multiply two 4x4 matrices.
+   *
+   * @param m1 an array of double (first matrix).
+   * @param m2 an array of double (second matrix).
+   * @param res Resultant matrix.
+   * @return Returns the matrix res.
+   */
+  public static double[][] mat4Mat4(double[][] m1, double[][] m2, double[][] res) {
+    assert(m1.length==4);
+    assert(m1[0].length==4);
+    assert(m2.length==4);
+    assert(m2[0].length==4);
+    assert(res.length==4);
+    assert(res[0].length==4);
+    res[0][0] = m1[0][0] * m2[0][0] + m1[0][1] * m2[1][0] + m1[0][2] * m2[2][0] + m1[0][3] * m2[3][0];
+    res[0][1] = m1[0][0] * m2[0][1] + m1[0][1] * m2[1][1] + m1[0][2] * m2[2][1] + m1[0][3] * m2[3][1];
+    res[0][2] = m1[0][0] * m2[0][2] + m1[0][1] * m2[1][2] + m1[0][2] * m2[2][2] + m1[0][3] * m2[3][2];
+    res[0][3] = m1[0][0] * m2[0][3] + m1[0][1] * m2[1][3] + m1[0][2] * m2[2][3] + m1[0][3] * m2[3][3];
+    res[1][0] = m1[1][0] * m2[0][0] + m1[1][1] * m2[1][0] + m1[1][2] * m2[2][0] + m1[1][3] * m2[3][0];
+    res[1][1] = m1[1][0] * m2[0][1] + m1[1][1] * m2[1][1] + m1[1][2] * m2[2][1] + m1[1][3] * m2[3][1];
+    res[1][2] = m1[1][0] * m2[0][2] + m1[1][1] * m2[1][2] + m1[1][2] * m2[2][2] + m1[1][3] * m2[3][2];
+    res[1][3] = m1[1][0] * m2[0][3] + m1[1][1] * m2[1][3] + m1[1][2] * m2[2][3] + m1[1][3] * m2[3][3];
+    res[2][0] = m1[2][0] * m2[0][0] + m1[2][1] * m2[1][0] + m1[2][2] * m2[2][0] + m1[2][3] * m2[3][0];
+    res[2][1] = m1[2][0] * m2[0][1] + m1[2][1] * m2[1][1] + m1[2][2] * m2[2][1] + m1[2][3] * m2[3][1];
+    res[2][2] = m1[2][0] * m2[0][2] + m1[2][1] * m2[1][2] + m1[2][2] * m2[2][2] + m1[2][3] * m2[3][2];
+    res[2][3] = m1[2][0] * m2[0][3] + m1[2][1] * m2[1][3] + m1[2][2] * m2[2][3] + m1[2][3] * m2[3][3];
+    res[3][0] = m1[3][0] * m2[0][0] + m1[3][1] * m2[1][0] + m1[3][2] * m2[2][0] + m1[3][3] * m2[3][0];
+    res[3][1] = m1[3][0] * m2[0][1] + m1[3][1] * m2[1][1] + m1[3][2] * m2[2][1] + m1[3][3] * m2[3][1];
+    res[3][2] = m1[3][0] * m2[0][2] + m1[3][1] * m2[1][2] + m1[3][2] * m2[2][2] + m1[3][3] * m2[3][2];
+    res[3][3] = m1[3][0] * m2[0][3] + m1[3][1] * m2[1][3] + m1[3][2] * m2[2][3] + m1[3][3] * m2[3][3];
+    return res;
+  }
+
+  /**
    * matrix times a vector representation of a symmetric 3x3 matrix
    *
    * @param m input matrix

--- a/modules/potential/src/main/java/ffx/potential/DualTopologyEnergy.java
+++ b/modules/potential/src/main/java/ffx/potential/DualTopologyEnergy.java
@@ -39,6 +39,7 @@ package ffx.potential;
 
 import static ffx.crystal.Crystal.applyCartesianSymOp;
 import static ffx.crystal.Crystal.applyCartesianSymRot;
+import static ffx.crystal.Crystal.invertSymOp;
 import static java.lang.Double.parseDouble;
 import static java.lang.String.format;
 import static java.util.Arrays.fill;
@@ -51,7 +52,6 @@ import ffx.crystal.Crystal;
 import ffx.crystal.CrystalPotential;
 import ffx.crystal.SymOp;
 import ffx.numerics.Potential;
-import ffx.numerics.math.Double3;
 import ffx.numerics.switching.UnivariateSwitchingFunction;
 import ffx.potential.bonded.Atom;
 import ffx.potential.bonded.LambdaInterface;
@@ -64,8 +64,6 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.configuration2.CompositeConfiguration;
-import org.apache.commons.math3.linear.MatrixUtils;
-import org.apache.commons.math3.linear.RealMatrix;
 
 /**
  * Compute the potential energy and derivatives for a dual-topology system.
@@ -373,10 +371,8 @@ public class DualTopologyEnergy implements CrystalPotential, LambdaInterface {
             {parseDouble(tokens[6]), parseDouble(tokens[7]), parseDouble(tokens[8])}},
             new double[] {parseDouble(tokens[9]), parseDouble(tokens[10]), parseDouble(tokens[11])});
         useSymOp = true;
-        RealMatrix rotation = MatrixUtils.createRealMatrix(symOp.rot);
-        Double3 translation = new Double3(symOp.tr);
         // Transpose == inverse for orthogonal matrices
-        inverse = new SymOp(rotation.transpose().getData(), translation.scale(-1.0).get());
+        inverse = invertSymOp(symOp);
         logger.info("\n Utilizing SymOp between systems:\n" + symOp);
         logger.info(" Inverse                        :\n" + inverse);
       } catch (Exception ex) {


### PR DESCRIPTION
PAC: Previous push inflated size was mistakenly based on asymmetric unit volume rather than RMSD_x. Adjusted default parameters to work for test set. Renamed inflated flag for accuracy. Updated PAC tests to be more decisive.

Crystal: Created an invertSymOp method.

Matrix Math: Added a 4x4 matrix multiplication. Used in PAC for printSym as symOps are stored as 4x4 arrays instead of a 3x3 rot and 3x1 translation.

DualTopology: Updated to use invertSymOp.