### PR TITLE
Fix SymOp inverse, improve efficiency for PAC, and increased DualTopology logging.

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -138,6 +138,13 @@ class SuperposeCrystals extends AlgorithmsScript {
   private static boolean permute
 
   /**
+   * --lm or --lowMemory Slower comparisons, but reduces memory usage.
+   */
+  @Option(names = ['--lm', '--lowMemory'], paramLabel = "false", defaultValue = "false",
+          description = 'Reduce memory usage at the cost of efficiency.')
+  private static boolean lowMemory
+
+  /**
    * --ac or --alphaCarbons Consider only alpha carbons for proteins.
    */
   @Option(names = ['--ac', '--alphaCarbons'], paramLabel = "false", defaultValue = "false",
@@ -290,7 +297,7 @@ class SuperposeCrystals extends AlgorithmsScript {
     runningStatistics =
         pac.comparisons(numAU, inflationFactor, matchTol, zPrime, zPrime2, alphaCarbons,
             includeHydrogen, massWeighted, crystalPriority, permute, save,
-            restart, write, machineLearning, inertia, gyrationComponents, linkage, printSym, pacFilename)
+            restart, write, machineLearning, inertia, gyrationComponents, linkage, printSym, lowMemory, pacFilename)
 
     return this
   }

--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/SuperposeCrystalsTest.java
@@ -51,7 +51,7 @@ import org.junit.Test;
 
 public class SuperposeCrystalsTest extends AlgorithmsTest {
 
-  private final double TOLERANCE = 0.002;
+  private final double TOLERANCE = 0.005;
 
   /** Tests the SuperposeCrystals script with default settings. */
   @Test

--- a/modules/crystal/src/main/java/ffx/crystal/SymOp.java
+++ b/modules/crystal/src/main/java/ffx/crystal/SymOp.java
@@ -694,8 +694,9 @@ public class SymOp {
   public static SymOp invertSymOp(SymOp symOp) {
     var tr = symOp.tr;
     var rot = symOp.rot;
-    return new SymOp(mat3Inverse(rot),
-        new double[] {-dot(tr, rot[0]), -dot(tr, rot[1]), -dot(tr, rot[2])});
+    var inv = mat3Inverse(rot);
+    return new SymOp(inv,
+        new double[] {-dot(inv[0], tr), -dot(inv[1], tr), -dot(inv[2], tr)});
   }
 
   /**


### PR DESCRIPTION
SymOp: Fixed error that occurred when calculating inverted translation.

PAC: Increase efficiency by adding caches for the inner loop. Traditional behavior can be obtained by utilizing "--lm" or "--lowMemory" flag. Start to include logic for PAC SymOps when Z'>1.

DualTopology: Added fine logging to display coordinates for SymOp analysis. Updated loop limits to start incorporation of differing Z' values between systems.