### PR TITLE
Efficiency updates for PAC.

### DIFF
--- a/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
+++ b/modules/algorithms/src/main/groovy/ffx/algorithms/groovy/SuperposeCrystals.groovy
@@ -65,7 +65,7 @@ import static org.apache.commons.io.FilenameUtils.getFullPath
  * <br>
  * Usage:
  * <br>
- * ffxc test.SuperposeCrystals &lt;filename&gt &lt;filename&gt;
+ * ffxc test.SuperposeCrystals &lt;filename&gt; &lt;filename&gt;
  */
 @Command(description = " Determine the RMSD for crystal polymorphs using the Progressive Alignment of Crystals (PAC) algorithm.",
     name = "ffxc SuperposeCrystals")

--- a/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/CIFFilter.java
@@ -1125,15 +1125,30 @@ public class CIFFilter extends SystemFilter{
      */
     @Override
     public boolean readNext(boolean resetPosition, boolean print) {
+        return readNext(resetPosition, print, true);
+    }
+
+    /**
+     * Reads the next snap-shot of an archive into the activeMolecularAssembly. After calling this
+     * function, a BufferedReader will remain open until the <code>close</code> method is called.
+     */
+    @Override
+    public boolean readNext(boolean resetPosition, boolean print, boolean parse) {
         List<CifCoreBlock> blocks = cifFile.getBlocks();
         CifCoreBlock currentBlock;
-        if(resetPosition){
+        if (!parse) {
+            snapShot++;
+            if(print){
+                logger.info(format(" Skipped Block: %d", snapShot));
+            }
+            return true;
+        } else if (resetPosition) {
             currentBlock = blocks.get(0);
             snapShot = 0;
-        }else if(++snapShot < blocks.size()){
+        } else if (++snapShot < blocks.size()) {
             currentBlock = blocks.get(snapShot);
-        }else{
-            if(print){
+        } else {
+            if (print) {
                 logger.info(" Reached end of available blocks in CIF file.");
             }
             return false;

--- a/modules/potential/src/main/java/ffx/potential/parsers/INTFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/INTFilter.java
@@ -344,6 +344,11 @@ public class INTFilter extends SystemFilter {
   public boolean readNext(boolean resetPosition, boolean print) {
     return false;
   }
+  /** {@inheritDoc} */
+  @Override
+  public boolean readNext(boolean resetPosition, boolean print, boolean parse) {
+    return false;
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/modules/potential/src/main/java/ffx/potential/parsers/MergeFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/MergeFilter.java
@@ -92,6 +92,12 @@ public class MergeFilter extends SystemFilter {
 
   /** {@inheritDoc} */
   @Override
+  public boolean readNext(boolean resetPosition, boolean print, boolean parse) {
+    return false;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public boolean readNext() {
     return readNext(false);
   }

--- a/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/PDBFilter.java
@@ -1408,11 +1408,23 @@ public final class PDBFilter extends SystemFilter {
   /** {@inheritDoc} */
   @Override
   public boolean readNext(boolean resetPosition, boolean print) {
+    return readNext(resetPosition, print, true);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean readNext(boolean resetPosition, boolean print, boolean parse) {
+    modelsRead = resetPosition ? 1 : modelsRead + 1;
+    if(!parse){
+      if(print){
+        logger.info(format(" Skipped Model %d.", modelsRead));
+      }
+      return true;
+    }
     remarkLines = new ArrayList<>(remarkLines.size());
     // ^ is beginning of line, \\s+ means "one or more whitespace", (\\d+) means match and capture
     // one or more digits.
     Pattern modelPatt = Pattern.compile("^MODEL\\s+(\\d+)");
-    modelsRead = resetPosition ? 1 : modelsRead + 1;
     boolean eof = true;
     for (MolecularAssembly system : systems) {
       try {

--- a/modules/potential/src/main/java/ffx/potential/parsers/SystemFilter.java
+++ b/modules/potential/src/main/java/ffx/potential/parsers/SystemFilter.java
@@ -865,6 +865,16 @@ public abstract class SystemFilter {
   public abstract boolean readNext(boolean resetPosition, boolean print);
 
   /**
+   * Reads the next model if applicable (currently, ARC files only).
+   *
+   * @param resetPosition Resets to first frame.
+   * @param print Flag to print.
+   * @param parse Parse data in file. May want to skip structures for parallel jobs.
+   * @return If next model read.
+   */
+  public abstract boolean readNext(boolean resetPosition, boolean print, boolean parse);
+
+  /**
    * Setter for the field <code>forceField</code>.
    *
    * @param forceField a {@link ffx.potential.parameters.ForceField} object.

--- a/modules/ui/src/main/java/ffx/ui/commands/SimulationFilter.java
+++ b/modules/ui/src/main/java/ffx/ui/commands/SimulationFilter.java
@@ -148,6 +148,11 @@ public final class SimulationFilter extends SystemFilter {
   }
 
   @Override
+  public boolean readNext(boolean resetPosition, boolean print, boolean parse) {
+    return false;
+  }
+
+  @Override
   public boolean readNext() {
     return readNext(false);
   }


### PR DESCRIPTION
Filters: Added a new extended method to SystemFilter for ReadNext(bool, bool, bool) method that determines whether the data in a file will be parsed or skipped over. This is particularly helpful for parallel efficiency where entries in a file may not be utilized by every node.

PAC: Utilized the new ReadNext method mentioned above. Increased some precision values in printSym and fixed an error with the per atom RMSD's when utilizing the shortcut for a single molecule. 