### PR TITLE
M x N neighbor list

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/nonbonded/NeighborList.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/NeighborList.java
@@ -158,6 +158,8 @@ public class NeighborList extends ParallelRegion {
    * Time to build the Verlet lists.
    */
   private long verletListTime;
+  /** Time to build groups and associated lists */
+  private long groupingTime;
   /** Total number of interactions. */
   private final SharedInteger sharedCount;
   /** Optimal pairwise ranges. */
@@ -309,7 +311,9 @@ public class NeighborList extends ParallelRegion {
     try {
       parallelTeam.execute(this);
       if(M > 1 && N > 1) {
+        groupingTime -= System.nanoTime();
         groups();
+        groupingTime += System.nanoTime();
       } else {
         groupLists = lists;
       }
@@ -381,6 +385,9 @@ public class NeighborList extends ParallelRegion {
       sb.append(format("   Create Vertlet Lists:   %6.4f sec\n", verletListTime * 1e-9));
       sb.append(format("   Parallel Schedule:      %6.4f sec\n", scheduleTime * 1e-9));
       sb.append(format("   Neighbor List Total:    %6.4f sec\n", time * 1e-9));
+      if ( M > 1 && N > 1) {
+        sb.append(format("   M x N List Total:       %6.4f sec\n", groupingTime * 1e-9));
+      }
       logger.fine(sb.toString());
     }
   }
@@ -1513,7 +1520,7 @@ public class NeighborList extends ParallelRegion {
    */
   public static void main(String[] args){
     PotentialsUtils potentialsUtils = new PotentialsUtils();
-    File xyzFile = new File("/home/matthew-speranza/Programs/forcefieldx/examples/trypsin.P21212.xyz");
+    File xyzFile = new File("./examples/trypsin.P21212.xyz");
     if(!xyzFile.exists()){
       System.out.println("File does not exist");
     }

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/NeighborList.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/NeighborList.java
@@ -372,7 +372,7 @@ public class NeighborList extends ParallelRegion {
     pairwiseSchedule.updateRanges(sharedCount.get(), atomsWithIteractions, listCount);
     scheduleTime += System.nanoTime();
 
-    if (logger.isLoggable(Level.WARNING)) {
+    if (logger.isLoggable(Level.FINE)) {
       time = System.nanoTime() - time;
       StringBuilder sb = new StringBuilder();
       sb.append(format("   Motion Check:           %6.4f sec\n", motionTime * 1e-9));
@@ -384,7 +384,7 @@ public class NeighborList extends ParallelRegion {
         sb.append(format("   M x N List Total:       %6.4f sec\n", groupingTime * 1e-9));
       }
       sb.append(format("   Neighbor List Total:    %6.4f sec\n", time * 1e-9));
-      logger.warning(sb.toString());
+      logger.fine(sb.toString());
     }
   }
 
@@ -554,48 +554,6 @@ public class NeighborList extends ParallelRegion {
     nGroups = symmGroups[0]; // symmGroups is uniform array
     groupLists = new int[nSymm][nGroups][]; // Last will be union of N atoms' list * N
     groupBitMasks = new boolean[nSymm][nGroups][];
-    /*
-    // Build lists
-    for(int i = 0; i < nSymm; i++){
-      for(int j = 0; j < nGroups; j++){
-        int[] group = groups[i][j];
-        // Fill out union and mask
-        HashSet<Integer> groupUnion = new HashSet<>();
-        ArrayList<boolean[]> groupMasks = new ArrayList<>();
-        HashMap<Integer, Integer> neighborIDToMaskIndex = new HashMap<>();
-        for(int k = 0; k < M; k++){
-          int atomID = group[k];
-          if (atomID == -1) {
-            continue;
-          }
-          int[] neighborList = lists[i][atomID];
-          for(int l = 0; l < neighborList.length; l++){
-            boolean newInteraction = groupUnion.add(neighborList[l]);
-            if(newInteraction){
-              groupMasks.add(new boolean[M]);
-              groupMasks.getLast()[k] = true;
-              neighborIDToMaskIndex.put(neighborList[l], groupMasks.size()-1);
-            } else {
-              int maskIndex = neighborIDToMaskIndex.get(neighborList[l]);
-              groupMasks.get(maskIndex)[k] = true;
-            }
-          }
-        }
-        int[] groupNeighborListExpanded = new int[groupUnion.size()*N];
-        boolean[] groupNeighborMasks = new boolean[groupUnion.size()*N];
-        List<Integer> groupNeighborList = groupUnion.stream().toList();
-        for(int k = 0; k < groupNeighborList.size(); k++){
-          int atomID = groupNeighborList.get(k);
-          for(int l = 0; l < N; l++){
-            groupNeighborListExpanded[k*N+l] = atomID;
-            groupNeighborMasks[k*N+l] = groupMasks.get(k)[l];
-          }
-        }
-        groupLists[i][j] = groupNeighborListExpanded;
-        groupBitMasks[i][j] = groupNeighborMasks;
-      }
-    }
-     */
   }
 
   /**
@@ -1580,7 +1538,7 @@ public class NeighborList extends ParallelRegion {
    */
   public static void main(String[] args){
     PotentialsUtils potentialsUtils = new PotentialsUtils();
-    File xyzFile = new File("./examples/dhfr2.xyz");
+    File xyzFile = new File("./examples/waterbox.xyz");
     if(!xyzFile.exists()){
       System.out.println("File does not exist");
     }

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwald.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwald.java
@@ -1428,7 +1428,7 @@ public class ParticleMeshEwald implements LambdaInterface {
         coords[0][i * 3 + 2] = atoms[i].getZ();
       }
       boolean print = logger.isLoggable(Level.FINE);
-      vacuumNeighborList.buildList(coords, alchemicalParameters.vaporLists, isSoft,
+      vacuumNeighborList.buildMxNList(1, 1, coords, alchemicalParameters.vaporLists, isSoft,
           true, print);
       alchemicalParameters.vaporPermanentSchedule = vacuumNeighborList.getPairwiseSchedule();
       alchemicalParameters.vaporEwaldSchedule = alchemicalParameters.vaporPermanentSchedule;
@@ -1510,7 +1510,7 @@ public class ParticleMeshEwald implements LambdaInterface {
         coords[0][i * 3 + 2] = atoms[i].getZ();
       }
       boolean print = logger.isLoggable(Level.FINE);
-      vacuumNeighborList.buildList(coords, alchemicalParameters.vaporLists, nnAtoms, true, print);
+      vacuumNeighborList.buildMxNList(1, 1, coords, alchemicalParameters.vaporLists, nnAtoms, true, print);
       alchemicalParameters.vaporPermanentSchedule = vacuumNeighborList.getPairwiseSchedule();
       alchemicalParameters.vaporEwaldSchedule = alchemicalParameters.vaporPermanentSchedule;
       alchemicalParameters.vacuumRanges = new Range[maxThreads];

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwald.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwald.java
@@ -1428,7 +1428,7 @@ public class ParticleMeshEwald implements LambdaInterface {
         coords[0][i * 3 + 2] = atoms[i].getZ();
       }
       boolean print = logger.isLoggable(Level.FINE);
-      vacuumNeighborList.buildMxNList(1, 1, coords, alchemicalParameters.vaporLists, isSoft,
+      vacuumNeighborList.buildList(coords, alchemicalParameters.vaporLists, isSoft,
           true, print);
       alchemicalParameters.vaporPermanentSchedule = vacuumNeighborList.getPairwiseSchedule();
       alchemicalParameters.vaporEwaldSchedule = alchemicalParameters.vaporPermanentSchedule;
@@ -1510,7 +1510,7 @@ public class ParticleMeshEwald implements LambdaInterface {
         coords[0][i * 3 + 2] = atoms[i].getZ();
       }
       boolean print = logger.isLoggable(Level.FINE);
-      vacuumNeighborList.buildMxNList(1, 1, coords, alchemicalParameters.vaporLists, nnAtoms, true, print);
+      vacuumNeighborList.buildList(coords, alchemicalParameters.vaporLists, nnAtoms, true, print);
       alchemicalParameters.vaporPermanentSchedule = vacuumNeighborList.getPairwiseSchedule();
       alchemicalParameters.vaporEwaldSchedule = alchemicalParameters.vaporPermanentSchedule;
       alchemicalParameters.vacuumRanges = new Range[maxThreads];


### PR DESCRIPTION
Currently generates verlet lists, forms groups, and then combines the verlet lists into groups while generating the required bitmasks for the SIMD operations.

To reduce this, we can form the groupLists while generating the verlet lists. 

Alternatively, we could extend the logic of the domain decomposition to "groups" in addition to AtomIndexs. I tried this, and realized there was a LOT of work to be done in the inclusion criteria, and went on the simpler route of using the existing logic (see commits separately for old strategy). That "group" code should be removed eventually, once one or the other is chosen (the z addition into the AtomIndex should stay though, since it is used to SORT within cells -> the way GROMACS does it).