### PR TITLE
Biotype.groovy was previosuly broken because the atoms array was neve…

### DIFF
--- a/modules/potential/src/main/groovy/ffx/potential/groovy/Biotype.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/Biotype.groovy
@@ -145,6 +145,7 @@ class Biotype extends PotentialScript {
 
     Molecule[] molecules = activeAssembly.getMoleculeArray()
 
+    Atom[] atoms = activeAssembly.getAtomArray()
     if (writeCONNECT) {
       for (Atom a : atoms) {
 // =============================================================================


### PR DESCRIPTION
…r defined. Sorry for the error!