### PR TITLE
Fixed the LITERS_PER_CUBIC_ANGSTROM constant

### DIFF
--- a/modules/potential/src/main/groovy/ffx/potential/groovy/Solvator.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/Solvator.groovy
@@ -513,8 +513,7 @@ class Solvator extends PotentialScript {
       // @formatter:on
       double volume = newBox[0] * newBox[1] * newBox[2]
       // newCrystal.volume may also work.
-      // The L -> mL and M -> mM conversions cancel.
-      double ionsPermM = volume * Constants.LITERS_PER_CUBIC_ANGSTROM * Constants.AVOGADRO
+      double ionsPermM = volume * Constants.LITERS_PER_CUBIC_ANGSTROM * Constants.AVOGADRO * 1E-3
 
       List<IonAddition> byConc = new ArrayList<>()
       IonAddition neutAnion = null

--- a/modules/utilities/src/main/java/ffx/utilities/Constants.java
+++ b/modules/utilities/src/main/java/ffx/utilities/Constants.java
@@ -105,7 +105,7 @@ public class Constants {
   /**
    * Constant <code>LITERS_PER_CUBIC_ANGSTROM=1E-30</code>
    */
-  public static final double LITERS_PER_CUBIC_ANGSTROM = 1E-30;
+  public static final double LITERS_PER_CUBIC_ANGSTROM = 1E-27;
   /**
    * Constant <code>ATM_TO_BAR=1.01325</code>
    */


### PR DESCRIPTION
One of the constants (LITERS_PER_CUBIC_ANGSTROM) is incorrectly assigned to be 1E-30 when it should be 1E-27. However, the concentration calculations that used this constant were correct as they did not divide by 1000 to go from M to mM. So, in a way the division was accounted for in the constant, but it was not immediately apparent and seems like bad practice to wrap that into a constant.