### PR TITLE
Added appropriate derivatives for total charge correction under CpHMD.

### DIFF
--- a/modules/potential/src/main/java/ffx/potential/extended/ExtendedSystem.java
+++ b/modules/potential/src/main/java/ffx/potential/extended/ExtendedSystem.java
@@ -149,6 +149,7 @@ public class ExtendedSystem implements Potential {
      */
     private final double LYStitrBiasMag;
     private final List<Constraint> constraints;
+    public final boolean useTotalChargeCorrection;
     private final boolean doBias;
     private final boolean doElectrostatics;
     private final boolean doPolarization;
@@ -317,6 +318,7 @@ public class ExtendedSystem implements Potential {
         doElectrostatics = properties.getBoolean("esv.elec", true);
         doBias = properties.getBoolean("esv.bias", true);
         doPolarization = properties.getBoolean("esv.polarization", true);
+        useTotalChargeCorrection = properties.getBoolean("esv.total.charge.correction", false);
         thetaFriction = properties.getDouble("esv.friction", ExtendedSystem.THETA_FRICTION);
         thetaMass = properties.getDouble("esv.mass", ExtendedSystem.THETA_MASS);
 

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/pme/ReciprocalEnergyRegion.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/pme/ReciprocalEnergyRegion.java
@@ -226,7 +226,7 @@ public class ReciprocalEnergyRegion extends ParallelRegion {
       permanentReciprocalEnergy += permanentReciprocalEnergyLoop[i].eRecip;
     }
 
-    if (totalCharge == 0.0) {
+    if (totalCharge == 0.0 || (esvTerm && !extendedSystem.useTotalChargeCorrection)) {
       chargeCorrectionEnergy = 0.0;
     } else {
       Crystal unitCell = crystal.getUnitCell();


### PR DESCRIPTION
However, the correction and these derivatives are not calculated by default when CpHMD is on. A flag must be set in conjunction to enable the calculation. This was done to avoid reparameterization of the model bias term and the problematic nature of the neutralizing plasma interaction being favorable. This favorability implies that the force with respect to a lambda state variable will push the system to more net charge.